### PR TITLE
Support deletions

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -2,7 +2,7 @@
 name: Benches on demand
 
 # on: push
-on: workflow_dispatch
+on: [workflow_dispatch, pull_request]
 
 jobs:
   bench:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 pkg/
 target/
 **/Cargo.lock
+perf*
+flamegraph.svg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- deletions in upsert
+- format of the Chain Table
+
 ## [3.1.0] - 2023-03-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -300,8 +300,6 @@ compared to 1 for the naive solution.
 Advantage of graphs: optimal storage of the locations info since they are not
 repeated in the chain table.
 
-TODO: what does the `size` represent?
-
 | Avg locations | #records graphs | #records naive | ratio | size (kb) graphs | size (kb) naive | ratio |
 |---------------|-----------------|----------------|-------|------------------|-----------------|-------|
 | 1             | 86018           | 86018          | 1.00  | 5605             | 5704            | 1.01  |

--- a/benches/BENCHMARKS.md
+++ b/benches/BENCHMARKS.md
@@ -1,0 +1,30 @@
+# Benchmarks
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Benchmark Results](#benchmark-results)
+    - [search](#search)
+    - [upsert](#upsert)
+
+## Overview
+
+This is a benchmark comparison report.
+
+## Benchmark Results
+
+### search
+
+|        | `Searching 1 word`          | `Searching 10 words`           | `Searching 100 words`          | `Searching 1000 words`           |
+|:-------|:----------------------------|:-------------------------------|:-------------------------------|:-------------------------------- |
+|        | `4.65 ms` (✅ **1.00x**)     | `5.03 ms` (✅ **1.08x slower**) | `6.41 ms` (❌ *1.38x slower*)   | `15.97 ms` (❌ *3.44x slower*)    |
+
+### upsert
+
+|        | `Indexing 20 keywords`          | `Indexing 200 keywords`          | `Indexing 2000 keywords`           |
+|:-------|:--------------------------------|:---------------------------------|:---------------------------------- |
+|        | `214.88 us` (✅ **1.00x**)       | `2.06 ms` (❌ *9.60x slower*)     | `21.32 ms` (❌ *99.21x slower*)     |
+
+---
+Made with [criterion-table](https://github.com/nu11ptr/criterion-table)
+

--- a/benches/BENCHMARKS.md
+++ b/benches/BENCHMARKS.md
@@ -17,13 +17,13 @@ This is a benchmark comparison report.
 
 |        | `Searching 1 word`          | `Searching 10 words`           | `Searching 100 words`          | `Searching 1000 words`           |
 |:-------|:----------------------------|:-------------------------------|:-------------------------------|:-------------------------------- |
-|        | `4.65 ms` (✅ **1.00x**)     | `5.03 ms` (✅ **1.08x slower**) | `6.41 ms` (❌ *1.38x slower*)   | `15.97 ms` (❌ *3.44x slower*)    |
+|        | `3.55 ms` (✅ **1.00x**)     | `3.76 ms` (✅ **1.06x slower**) | `4.43 ms` (❌ *1.25x slower*)   | `14.23 ms` (❌ *4.00x slower*)    |
 
 ### upsert
 
 |        | `Indexing 20 keywords`          | `Indexing 200 keywords`          | `Indexing 2000 keywords`           |
 |:-------|:--------------------------------|:---------------------------------|:---------------------------------- |
-|        | `214.88 us` (✅ **1.00x**)       | `2.06 ms` (❌ *9.60x slower*)     | `21.32 ms` (❌ *99.21x slower*)     |
+|        | `214.79 us` (✅ **1.00x**)       | `2.07 ms` (❌ *9.63x slower*)     | `21.45 ms` (❌ *99.85x slower*)     |
 
 ---
 Made with [criterion-table](https://github.com/nu11ptr/criterion-table)

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -56,7 +56,7 @@ fn bench_search(c: &mut Criterion) {
     // Prepare indexes to be search
     //
     let mut findex = FindexInMemory::default();
-    block_on(findex.upsert(locations_and_words, &master_key, &label)).expect("msg");
+    block_on(findex.upsert(locations_and_words, HashMap::new(), &master_key, &label)).expect("msg");
 
     println!("Entry Table length: {}", findex.entry_table_len());
     println!("Entry Table size: {}", findex.entry_table_size());
@@ -168,7 +168,12 @@ fn bench_upsert(c: &mut Criterion) {
     group.bench_function("Indexing 20 keywords", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             FindexInMemory::default()
-                .upsert(locations_and_words.clone(), &master_key, &label)
+                .upsert(
+                    locations_and_words.clone(),
+                    HashMap::new(),
+                    &master_key,
+                    &label,
+                )
                 .await
                 .expect("upsert failed");
         });
@@ -177,7 +182,12 @@ fn bench_upsert(c: &mut Criterion) {
     group.bench_function("Indexing 200 keywords", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             FindexInMemory::default()
-                .upsert(locations_and_words.clone(), &master_key, &label)
+                .upsert(
+                    locations_and_words.clone(),
+                    HashMap::new(),
+                    &master_key,
+                    &label,
+                )
                 .await
                 .expect("upsert failed");
         });
@@ -186,7 +196,12 @@ fn bench_upsert(c: &mut Criterion) {
     group.bench_function("Indexing 2000 keywords", |b| {
         b.to_async(FuturesExecutor).iter(|| async {
             FindexInMemory::default()
-                .upsert(locations_and_words.clone(), &master_key, &label)
+                .upsert(
+                    locations_and_words.clone(),
+                    HashMap::new(),
+                    &master_key,
+                    &label,
+                )
                 .await
                 .expect("upsert failed");
         });

--- a/benches/generate.sh
+++ b/benches/generate.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
+# Usage: bash generate.sh
 
 set -e
-
-# Usage: bash generate.sh
 
 cargo install cargo-criterion
 cargo install criterion-table
@@ -11,4 +10,3 @@ cargo criterion --features in_memory --message-format=json | criterion-table >be
 
 sed -i "s/❌ //g" benches/BENCHMARKS*.md
 sed -i "s/🚀 //g" benches/BENCHMARKS*.md
-# sed -i "s/✅ //g" benches/BENCHMARKS*.md

--- a/datasets/first_names.txt
+++ b/datasets/first_names.txt
@@ -2695,7 +2695,7 @@ Bhagwan
 Bhajan
 Bharat
 Bharata
-Bharata 
+Bharata
 Bharti
 Bhavna
 Bhima

--- a/examples/upsert.rs
+++ b/examples/upsert.rs
@@ -1,6 +1,3 @@
-#![allow(incomplete_features)]
-#![feature(async_fn_in_trait)]
-
 #[cfg(feature = "in_memory")]
 use std::collections::{HashMap, HashSet};
 

--- a/examples/upsert.rs
+++ b/examples/upsert.rs
@@ -59,7 +59,7 @@ fn main() {
 
         let mut findex = FindexInMemory::default();
 
-        for _ in 0..100 {
+        for _ in 0..100000 {
             block_on(findex.upsert(indexed_value_to_keywords.clone(), &master_key, &label))
                 .unwrap();
         }

--- a/examples/upsert.rs
+++ b/examples/upsert.rs
@@ -60,8 +60,13 @@ fn main() {
         let mut findex = FindexInMemory::default();
 
         for _ in 0..100000 {
-            block_on(findex.upsert(indexed_value_to_keywords.clone(), &master_key, &label))
-                .unwrap();
+            block_on(findex.upsert(
+                indexed_value_to_keywords.clone(),
+                HashMap::new(),
+                &master_key,
+                &label,
+            ))
+            .unwrap();
         }
     }
 }

--- a/src/chain_table.rs
+++ b/src/chain_table.rs
@@ -283,8 +283,7 @@ mod tests {
         let indexed_value_1 = IndexedValue::from(Location::from("location1".as_bytes()));
         let indexed_value_2 = IndexedValue::from(Location::from("location2".as_bytes()));
         let mut chain_table_value = ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::default();
-        for block in
-            Block::<BLOCK_LENGTH>::pad(InsertionType::Addition, &indexed_value_1.to_vec()).unwrap()
+        for block in Block::<BLOCK_LENGTH>::pad(InsertionType::Addition, &indexed_value_1).unwrap()
         {
             chain_table_value.try_push(block).unwrap();
         }
@@ -292,8 +291,7 @@ mod tests {
         assert_eq!(chain_table_value.length(), bytes.len());
         let res = ChainTableValue::try_from_bytes(&bytes).unwrap();
         assert_eq!(chain_table_value, res);
-        for block in
-            Block::<BLOCK_LENGTH>::pad(InsertionType::Addition, &indexed_value_2.to_vec()).unwrap()
+        for block in Block::<BLOCK_LENGTH>::pad(InsertionType::Addition, &indexed_value_2).unwrap()
         {
             chain_table_value.try_push(block).unwrap();
         }
@@ -316,17 +314,17 @@ mod tests {
         let indexed_value2 = IndexedValue::from(location);
 
         let mut chain_table_value1 = ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::default();
-        for block in Block::pad(InsertionType::Addition, &indexed_value1.to_vec()).unwrap() {
+        for block in Block::pad(InsertionType::Addition, &indexed_value1).unwrap() {
             chain_table_value1.try_push(block).unwrap();
         }
-        for block in Block::pad(InsertionType::Deletion, &indexed_value2.to_vec()).unwrap() {
+        for block in Block::pad(InsertionType::Deletion, &indexed_value2).unwrap() {
             chain_table_value1.try_push(block).unwrap();
         }
         // The indexed values should be short enough to fit in a single block.
         assert_eq!(chain_table_value1.length, 2);
 
         let mut chain_table_value2 = ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::default();
-        for block in Block::pad(InsertionType::Addition, &indexed_value1.to_vec()).unwrap() {
+        for block in Block::pad(InsertionType::Addition, &indexed_value1).unwrap() {
             chain_table_value2.try_push(block).unwrap();
         }
         // The indexed values should be short enough to fit in a single block.

--- a/src/chain_table.rs
+++ b/src/chain_table.rs
@@ -283,14 +283,14 @@ mod tests {
         let indexed_value_1 = IndexedValue::from(Location::from("location1".as_bytes()));
         let indexed_value_2 = IndexedValue::from(Location::from("location2".as_bytes()));
         let mut chain_table_value = ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::default();
-        for block in Block::<BLOCK_LENGTH>::pad(BlockType::Addition, &indexed_value_1).unwrap() {
+        for block in indexed_value_1.to_blocks(BlockType::Addition).unwrap() {
             chain_table_value.try_push(block).unwrap();
         }
         let bytes = chain_table_value.try_to_bytes().unwrap();
         assert_eq!(chain_table_value.length(), bytes.len());
         let res = ChainTableValue::try_from_bytes(&bytes).unwrap();
         assert_eq!(chain_table_value, res);
-        for block in Block::<BLOCK_LENGTH>::pad(BlockType::Addition, &indexed_value_2).unwrap() {
+        for block in indexed_value_2.to_blocks(BlockType::Addition).unwrap() {
             chain_table_value.try_push(block).unwrap();
         }
         let bytes = chain_table_value.try_to_bytes().unwrap();
@@ -312,17 +312,17 @@ mod tests {
         let indexed_value2 = IndexedValue::from(location);
 
         let mut chain_table_value1 = ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::default();
-        for block in Block::pad(BlockType::Addition, &indexed_value1).unwrap() {
+        for block in indexed_value1.to_blocks(BlockType::Addition).unwrap() {
             chain_table_value1.try_push(block).unwrap();
         }
-        for block in Block::pad(BlockType::Deletion, &indexed_value2).unwrap() {
+        for block in indexed_value2.to_blocks(BlockType::Deletion).unwrap() {
             chain_table_value1.try_push(block).unwrap();
         }
         // The indexed values should be short enough to fit in a single block.
         assert_eq!(chain_table_value1.length, 2);
 
         let mut chain_table_value2 = ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::default();
-        for block in Block::pad(BlockType::Addition, &indexed_value1).unwrap() {
+        for block in indexed_value1.to_blocks(BlockType::Addition).unwrap() {
             chain_table_value2.try_push(block).unwrap();
         }
         // The indexed values should be short enough to fit in a single block.

--- a/src/chain_table.rs
+++ b/src/chain_table.rs
@@ -42,12 +42,15 @@ impl<const BLOCK_LENGTH: usize> ChainTableValue<BLOCK_LENGTH> {
     /// Creates a new Chain Table value with the given blocks.
     ///
     /// - `blocks`  : blocks to store in this Chain Table entry.
-    pub fn new<const TABLE_WIDTH: usize>(blocks: Vec<Block<BLOCK_LENGTH>>) -> Result<Self, Error> {
+    pub fn new<const TABLE_WIDTH: usize>(
+        mut blocks: Vec<Block<BLOCK_LENGTH>>,
+    ) -> Result<Self, Error> {
         if blocks.len() > TABLE_WIDTH {
             return Err(Error::ConversionError(format!(
                 "Cannot add more than {TABLE_WIDTH} values inside a `ChainTableValue`"
             )));
         }
+        blocks.reserve_exact(TABLE_WIDTH - blocks.len());
         Ok(Self(blocks))
     }
 

--- a/src/chain_table.rs
+++ b/src/chain_table.rs
@@ -28,7 +28,7 @@ use cosmian_crypto_core::{
 
 use crate::{
     error::CoreError as Error,
-    structs::{Block, BlockPrefix, InsertionType, Uid},
+    structs::{Block, BlockPrefix, BlockType, Uid},
     KeyingMaterial, CHAIN_TABLE_KEY_DERIVATION_INFO,
 };
 
@@ -145,9 +145,9 @@ impl<const TABLE_WIDTH: usize, const BLOCK_LENGTH: usize> Serializable
             let data = de.read_array::<BLOCK_LENGTH>()?;
             if BlockPrefix::Padding != prefix {
                 let block_type = if flag % 2 == 1 {
-                    InsertionType::Addition
+                    BlockType::Addition
                 } else {
-                    InsertionType::Deletion
+                    BlockType::Deletion
                 };
                 res.try_push(Block {
                     block_type,
@@ -283,16 +283,14 @@ mod tests {
         let indexed_value_1 = IndexedValue::from(Location::from("location1".as_bytes()));
         let indexed_value_2 = IndexedValue::from(Location::from("location2".as_bytes()));
         let mut chain_table_value = ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::default();
-        for block in Block::<BLOCK_LENGTH>::pad(InsertionType::Addition, &indexed_value_1).unwrap()
-        {
+        for block in Block::<BLOCK_LENGTH>::pad(BlockType::Addition, &indexed_value_1).unwrap() {
             chain_table_value.try_push(block).unwrap();
         }
         let bytes = chain_table_value.try_to_bytes().unwrap();
         assert_eq!(chain_table_value.length(), bytes.len());
         let res = ChainTableValue::try_from_bytes(&bytes).unwrap();
         assert_eq!(chain_table_value, res);
-        for block in Block::<BLOCK_LENGTH>::pad(InsertionType::Addition, &indexed_value_2).unwrap()
-        {
+        for block in Block::<BLOCK_LENGTH>::pad(BlockType::Addition, &indexed_value_2).unwrap() {
             chain_table_value.try_push(block).unwrap();
         }
         let bytes = chain_table_value.try_to_bytes().unwrap();
@@ -314,17 +312,17 @@ mod tests {
         let indexed_value2 = IndexedValue::from(location);
 
         let mut chain_table_value1 = ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::default();
-        for block in Block::pad(InsertionType::Addition, &indexed_value1).unwrap() {
+        for block in Block::pad(BlockType::Addition, &indexed_value1).unwrap() {
             chain_table_value1.try_push(block).unwrap();
         }
-        for block in Block::pad(InsertionType::Deletion, &indexed_value2).unwrap() {
+        for block in Block::pad(BlockType::Deletion, &indexed_value2).unwrap() {
             chain_table_value1.try_push(block).unwrap();
         }
         // The indexed values should be short enough to fit in a single block.
         assert_eq!(chain_table_value1.length, 2);
 
         let mut chain_table_value2 = ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::default();
-        for block in Block::pad(InsertionType::Addition, &indexed_value1).unwrap() {
+        for block in Block::pad(BlockType::Addition, &indexed_value1).unwrap() {
             chain_table_value2.try_push(block).unwrap();
         }
         // The indexed values should be short enough to fit in a single block.

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -3,7 +3,6 @@
 use std::collections::{HashMap, HashSet};
 
 use cosmian_crypto_core::{
-    bytes_ser_de::Serializable,
     reexport::rand_core::SeedableRng,
     symmetric_crypto::{Dem, SymKey},
     CsRng,
@@ -139,20 +138,11 @@ pub trait FindexCompact<
         // Get the values stored in the reindexed chains.
         let mut reindexed_chain_values = HashMap::with_capacity(chains_to_reindex.len());
         for (kwi, chain) in chains_to_reindex {
-            let mut indexed_values = HashSet::new();
             let blocks = chain
                 .into_iter()
                 .flat_map(|(_, chain_value)| chain_value.as_blocks().to_vec())
                 .collect::<Vec<_>>();
-            for (block_type, bytes) in Block::unpad(&blocks)? {
-                let value = IndexedValue::try_from_bytes(&bytes)?;
-                if InsertionType::Addition == block_type {
-                    indexed_values.insert(value);
-                } else {
-                    indexed_values.remove(&value);
-                }
-            }
-            reindexed_chain_values.insert(kwi.clone(), indexed_values);
+            reindexed_chain_values.insert(kwi.clone(), Block::unpad(&blocks)?);
         }
 
         //

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -142,7 +142,7 @@ pub trait FindexCompact<
                 .into_iter()
                 .flat_map(|(_, chain_value)| chain_value.as_blocks().to_vec())
                 .collect::<Vec<_>>();
-            reindexed_chain_values.insert(kwi.clone(), Block::unpad(&blocks)?);
+            reindexed_chain_values.insert(kwi.clone(), Block::unpad(blocks)?);
         }
 
         //

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -13,7 +13,7 @@ use crate::{
     chain_table::{ChainTableValue, KwiChainUids},
     entry_table::{EntryTable, EntryTableValue},
     error::CallbackError,
-    structs::{Block, BlockType, EncryptedTable, IndexedValue, Label, Uid},
+    structs::{BlockType, EncryptedTable, IndexedValue, Label, Uid},
     Error, FindexCallbacks, KeyingMaterial, CHAIN_TABLE_KEY_DERIVATION_INFO,
     ENTRY_TABLE_KEY_DERIVATION_INFO,
 };
@@ -142,7 +142,7 @@ pub trait FindexCompact<
                 .into_iter()
                 .flat_map(|(_, chain_value)| chain_value.as_blocks().to_vec())
                 .collect::<Vec<_>>();
-            reindexed_chain_values.insert(kwi.clone(), Block::unpad(blocks)?);
+            reindexed_chain_values.insert(kwi.clone(), IndexedValue::from_blocks(blocks)?);
         }
 
         //

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -13,6 +13,7 @@ use crate::{
     chain_table::{ChainTableValue, KwiChainUids},
     entry_table::{EntryTable, EntryTableValue},
     error::CallbackError,
+    parameters::check_parameter_constraints,
     structs::{BlockType, EncryptedTable, IndexedValue, Label, Uid},
     Error, FindexCallbacks, KeyingMaterial, CHAIN_TABLE_KEY_DERIVATION_INFO,
     ENTRY_TABLE_KEY_DERIVATION_INFO,
@@ -63,6 +64,7 @@ pub trait FindexCompact<
         new_master_key: &KeyingMaterial<MASTER_KEY_LENGTH>,
         label: &Label,
     ) -> Result<(), Error<CustomError>> {
+        check_parameter_constraints::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>();
         if num_reindexing_before_full_set == 0 {
             return Err(Error::CryptoError(
                 "`num_reindexing_before_full_set` cannot be 0.".to_owned(),

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -142,9 +142,9 @@ pub trait FindexCompact<
         for (kwi, chain) in chains_to_reindex {
             let blocks = chain
                 .into_iter()
-                .flat_map(|(_, chain_value)| chain_value.as_blocks().to_vec())
+                .flat_map(|(_, chain_value)| chain_value.into_blocks())
                 .collect::<Vec<_>>();
-            reindexed_chain_values.insert(kwi.clone(), IndexedValue::from_blocks(blocks)?);
+            reindexed_chain_values.insert(kwi.clone(), IndexedValue::from_blocks(blocks.iter())?);
         }
 
         //

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -13,7 +13,7 @@ use crate::{
     chain_table::{ChainTableValue, KwiChainUids},
     entry_table::{EntryTable, EntryTableValue},
     error::CallbackError,
-    structs::{Block, EncryptedTable, IndexedValue, InsertionType, Label, Uid},
+    structs::{Block, BlockType, EncryptedTable, IndexedValue, Label, Uid},
     Error, FindexCallbacks, KeyingMaterial, CHAIN_TABLE_KEY_DERIVATION_INFO,
     ENTRY_TABLE_KEY_DERIVATION_INFO,
 };
@@ -212,7 +212,7 @@ pub trait FindexCompact<
             // Upsert each remaining location in the Chain Table.
             for remaining_location in remaining_indexed_values_for_this_keyword {
                 new_entry_table_value.upsert_indexed_value::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH, KMAC_KEY_LENGTH, DEM_KEY_LENGTH, KmacKey, DemScheme>(
-                    InsertionType::Addition,
+                    BlockType::Addition,
                     &remaining_location,
                     &kwi_uid,
                     &kwi_value,

--- a/src/entry_table.rs
+++ b/src/entry_table.rs
@@ -602,11 +602,10 @@ mod tests {
                     Aes256GcmCrypto,
                 >(&kwi_value, encrypted_chain_table_value)
                 .unwrap()
-                .as_blocks()
-                .to_vec()
+                .into_blocks()
             })
             .collect();
-        let indexed_values = IndexedValue::from_blocks(blocks).unwrap();
+        let indexed_values = IndexedValue::from_blocks(blocks.iter()).unwrap();
 
         // Assert the correct indexed values have been recovered.
         assert_eq!(indexed_values.len(), CHAIN_TABLE_WIDTH + 1);
@@ -653,11 +652,10 @@ mod tests {
                     Aes256GcmCrypto,
                 >(&kwi_value, encrypted_chain_table_value)
                 .unwrap()
-                .as_blocks()
-                .to_vec()
+                .into_blocks()
             })
             .collect();
-        let indexed_values = IndexedValue::from_blocks(blocks).unwrap();
+        let indexed_values = IndexedValue::from_blocks(blocks.iter()).unwrap();
 
         // Assert the correct indexed values have been recovered.
         assert_eq!(indexed_values.len(), 1);
@@ -726,12 +724,11 @@ mod tests {
                     Aes256GcmCrypto,
                 >(&kwi_value, encrypted_chain_table_value)
                 .unwrap()
-                .as_blocks()
-                .to_vec()
+                .into_blocks()
             })
             .collect();
 
-        let indexed_values = IndexedValue::from_blocks(blocks).unwrap();
+        let indexed_values = IndexedValue::from_blocks(blocks.iter()).unwrap();
 
         assert_eq!(indexed_values.len(), 1);
 

--- a/src/entry_table.rs
+++ b/src/entry_table.rs
@@ -602,7 +602,7 @@ mod tests {
                 .to_vec()
             })
             .collect();
-        let indexed_values = Block::<BLOCK_LENGTH>::unpad(&blocks).unwrap();
+        let indexed_values = Block::<BLOCK_LENGTH>::unpad(blocks).unwrap();
 
         // Assert the correct indexed values have been recovered.
         assert_eq!(indexed_values.len(), CHAIN_TABLE_WIDTH + 1);
@@ -653,7 +653,7 @@ mod tests {
                 .to_vec()
             })
             .collect();
-        let indexed_values = Block::<BLOCK_LENGTH>::unpad(&blocks).unwrap();
+        let indexed_values = Block::<BLOCK_LENGTH>::unpad(blocks).unwrap();
 
         // Assert the correct indexed values have been recovered.
         assert_eq!(indexed_values.len(), 1);
@@ -727,7 +727,7 @@ mod tests {
             })
             .collect();
 
-        let indexed_values = Block::<BLOCK_LENGTH>::unpad(&blocks).unwrap();
+        let indexed_values = Block::<BLOCK_LENGTH>::unpad(blocks).unwrap();
 
         assert_eq!(indexed_values.len(), 1);
 

--- a/src/entry_table.rs
+++ b/src/entry_table.rs
@@ -20,7 +20,7 @@ use crate::{
     chain_table::{ChainTable, ChainTableValue, KwiChainUids},
     error::CoreError as Error,
     keys::KeyCache,
-    structs::{Block, BlockType, EncryptedTable, IndexedValue, Label, Uid},
+    structs::{BlockType, EncryptedTable, IndexedValue, Label, Uid},
     KeyingMaterial, Keyword, CHAIN_TABLE_KEY_DERIVATION_INFO,
 };
 
@@ -134,7 +134,7 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
                 ChainTableValue::default()
             };
 
-        for block in Block::pad(insertion_type, indexed_value)? {
+        for block in indexed_value.to_blocks(insertion_type)? {
             if chain_table_value.as_blocks().len() >= CHAIN_TABLE_WIDTH {
                 // Encrypt and insert the current value in the Chain Table.
                 let encrypted_chain_table_value =
@@ -507,7 +507,11 @@ mod tests {
     };
 
     use super::*;
-    use crate::{parameters::*, structs::Location, Keyword, ENTRY_TABLE_KEY_DERIVATION_INFO};
+    use crate::{
+        parameters::*,
+        structs::{Block, Location},
+        Keyword, ENTRY_TABLE_KEY_DERIVATION_INFO,
+    };
 
     #[test]
     fn test_encryption() {
@@ -602,7 +606,7 @@ mod tests {
                 .to_vec()
             })
             .collect();
-        let indexed_values = Block::<BLOCK_LENGTH>::unpad(blocks).unwrap();
+        let indexed_values = IndexedValue::from_blocks(blocks).unwrap();
 
         // Assert the correct indexed values have been recovered.
         assert_eq!(indexed_values.len(), CHAIN_TABLE_WIDTH + 1);
@@ -653,7 +657,7 @@ mod tests {
                 .to_vec()
             })
             .collect();
-        let indexed_values = Block::<BLOCK_LENGTH>::unpad(blocks).unwrap();
+        let indexed_values = IndexedValue::from_blocks(blocks).unwrap();
 
         // Assert the correct indexed values have been recovered.
         assert_eq!(indexed_values.len(), 1);
@@ -727,7 +731,7 @@ mod tests {
             })
             .collect();
 
-        let indexed_values = Block::<BLOCK_LENGTH>::unpad(blocks).unwrap();
+        let indexed_values = IndexedValue::from_blocks(blocks).unwrap();
 
         assert_eq!(indexed_values.len(), 1);
 

--- a/src/entry_table.rs
+++ b/src/entry_table.rs
@@ -20,7 +20,7 @@ use crate::{
     chain_table::{ChainTable, ChainTableValue, KwiChainUids},
     error::CoreError as Error,
     keys::KeyCache,
-    structs::{Block, EncryptedTable, IndexedValue, Label, Uid},
+    structs::{Block, BlockType, EncryptedTable, IndexedValue, Label, Uid},
     KeyingMaterial, Keyword, CHAIN_TABLE_KEY_DERIVATION_INFO,
 };
 
@@ -50,6 +50,7 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
     /// - `rng`             : random number generator
     /// - `keyword_hash`    : hash of the indexing keyword
     pub(crate) fn new<
+        const CHAIN_TABLE_WITH: usize,
         const BLOCK_LENGTH: usize,
         const KMAC_KEY_LENGTH: usize,
         KmacKey: SymKey<KMAC_KEY_LENGTH>,
@@ -60,7 +61,10 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
         let kwi = KeyingMaterial::new(rng);
         let kwi_uid: KmacKey = kwi.derive_kmac_key(CHAIN_TABLE_KEY_DERIVATION_INFO);
         let chain_table_uid =
-            ChainTable::<UID_LENGTH, BLOCK_LENGTH>::generate_uid(&kwi_uid, &keyword_hash);
+            ChainTable::<UID_LENGTH, CHAIN_TABLE_WITH, BLOCK_LENGTH>::generate_uid(
+                &kwi_uid,
+                &keyword_hash,
+            );
         Self {
             chain_table_uid,
             kwi,
@@ -73,6 +77,7 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
     ///
     /// - `kwi_uid` : KMAC key used to generate Chain Table UIDs.
     pub(crate) fn next_chain_table_uid<
+        const CHAIN_TABLE_WITH: usize,
         const BLOCK_LENGTH: usize,
         const KMAC_KEY_LENGTH: usize,
         KmacKey: SymKey<KMAC_KEY_LENGTH>,
@@ -81,7 +86,10 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
         kwi_uid: &KmacKey,
     ) -> &Uid<UID_LENGTH> {
         self.chain_table_uid =
-            ChainTable::<UID_LENGTH, BLOCK_LENGTH>::generate_uid(kwi_uid, &self.chain_table_uid);
+            ChainTable::<UID_LENGTH, CHAIN_TABLE_WITH, BLOCK_LENGTH>::generate_uid(
+                kwi_uid,
+                &self.chain_table_uid,
+            );
         &self.chain_table_uid
     }
 
@@ -96,8 +104,8 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
     /// - `chain_table`     : Chain Table to which to upsert the given value
     /// - `rng`             : random number generator
     pub fn upsert_indexed_value<
+        const CHAIN_TABLE_WIDTH: usize,
         const BLOCK_LENGTH: usize,
-        const TABLE_WIDTH: usize,
         const KMAC_KEY_LENGTH: usize,
         const DEM_KEY_LENGTH: usize,
         KmacKey: SymKey<KMAC_KEY_LENGTH>,
@@ -116,33 +124,32 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
     ) -> Result<(), Error> {
         let mut chain_table_value =
             if let Some(encrypted_chain_table_value) = chain_table.get(&self.chain_table_uid) {
-                ChainTableValue::<BLOCK_LENGTH>::decrypt::<TABLE_WIDTH, DEM_KEY_LENGTH, DemScheme>(
-                    kwi_value,
-                    encrypted_chain_table_value,
-                )?
+                ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::decrypt::<
+                    DEM_KEY_LENGTH,
+                    DemScheme,
+                >(kwi_value, encrypted_chain_table_value)?
             } else {
                 // This the first time a value is indexed for this `Keyword`.
-                ChainTableValue::new::<TABLE_WIDTH>(vec![])?
+                ChainTableValue::default()
             };
 
-        for block in Block::pad(&indexed_value.to_vec())? {
-            if chain_table_value.len() < TABLE_WIDTH {
-                // There is still room for a new `Block`.
-                chain_table_value.push(block);
-            } else {
+        for block in Block::pad(BlockType::Addition, &indexed_value.to_vec())? {
+            if chain_table_value.as_blocks().len() >= CHAIN_TABLE_WIDTH {
                 // Encrypt and insert the current value in the Chain Table.
-                let encrypted_chain_table_value = chain_table_value
-                    .encrypt::<TABLE_WIDTH, DEM_KEY_LENGTH, DemScheme>(kwi_value, rng)?;
+                let encrypted_chain_table_value =
+                    chain_table_value.encrypt::<DEM_KEY_LENGTH, DemScheme>(kwi_value, rng)?;
                 chain_table.insert(self.chain_table_uid.clone(), encrypted_chain_table_value);
                 // Start a new line in the chain.
-                self.next_chain_table_uid::<BLOCK_LENGTH, KMAC_KEY_LENGTH, KmacKey>(kwi_uid);
-                chain_table_value = ChainTableValue::new::<TABLE_WIDTH>(vec![block])?;
+                self.next_chain_table_uid::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH, KMAC_KEY_LENGTH, KmacKey>(kwi_uid);
+                chain_table_value = ChainTableValue::default();
             }
+            // There is still room for a new `Block`.
+            chain_table_value.try_push(block)?;
         }
 
         // Encrypt and insert the value in the Chain Table.
         let encrypted_chain_table_value =
-            chain_table_value.encrypt::<TABLE_WIDTH, DEM_KEY_LENGTH, DemScheme>(kwi_value, rng)?;
+            chain_table_value.encrypt::<DEM_KEY_LENGTH, DemScheme>(kwi_value, rng)?;
         chain_table.insert(self.chain_table_uid.clone(), encrypted_chain_table_value);
         Ok(())
     }
@@ -208,6 +215,7 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
     /// - `kwi_chain_table_uids`    : (output) maps the `𝐾_{𝑤_𝑖}` with the Chain
     ///   Table UIDs
     pub(crate) fn unchain<
+        const CHAIN_TABLE_WIDTH: usize,
         const BLOCK_LENGTH: usize,
         const KMAC_KEY_LENGTH: usize,
         const DEM_KEY_LENGTH: usize,
@@ -226,7 +234,10 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
 
         // derive the Chain Table UID
         let mut current_chain_table_uid =
-            ChainTable::<UID_LENGTH, BLOCK_LENGTH>::generate_uid(&kwi_uid, &self.keyword_hash);
+            ChainTable::<UID_LENGTH, CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::generate_uid(
+                &kwi_uid,
+                &self.keyword_hash,
+            );
 
         for _ in 0..max_results {
             // add the new Chain Table UID to the map
@@ -238,10 +249,11 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
             }
 
             // compute the next UID
-            current_chain_table_uid = ChainTable::<UID_LENGTH, BLOCK_LENGTH>::generate_uid(
-                &kwi_uid,
-                &current_chain_table_uid,
-            );
+            current_chain_table_uid =
+                ChainTable::<UID_LENGTH, CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::generate_uid(
+                    &kwi_uid,
+                    &current_chain_table_uid,
+                );
         }
     }
 }
@@ -361,6 +373,7 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTable<UID_LENGTH, KW
     ///   per entry
     pub fn unchain<
         'a,
+        const CHAIN_TABLE_WITH: usize,
         const BLOCK_LENGTH: usize,
         const KMAC_KEY_LENGTH: usize,
         const DEM_KEY_LENGTH: usize,
@@ -374,7 +387,7 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTable<UID_LENGTH, KW
         let mut kwi_chain_table_uids = KwiChainUids::default();
         for entry_table_uid in uids {
             if let Some(value) = self.get(entry_table_uid) {
-                value.unchain::<BLOCK_LENGTH, KMAC_KEY_LENGTH, DEM_KEY_LENGTH, KmacKey, DemScheme>(
+                value.unchain::<CHAIN_TABLE_WITH, BLOCK_LENGTH, KMAC_KEY_LENGTH, DEM_KEY_LENGTH, KmacKey, DemScheme>(
                     max_results_per_uid,
                     &mut kwi_chain_table_uids,
                 );
@@ -413,8 +426,8 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTable<UID_LENGTH, KW
     /// - `new_entries`         : map values to their indexing keywords
     /// - `keywords_to_upsert`  : map keywords to their derived Entry Table UID
     pub fn upsert<
+        const CHAIN_TABLE_WIDTH: usize,
         const BLOCK_LENGTH: usize,
-        const TABLE_WIDTH: usize,
         const KMAC_KEY_LENGTH: usize,
         const DEM_KEY_LENGTH: usize,
         KmacKey: SymKey<KMAC_KEY_LENGTH>,
@@ -453,10 +466,10 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTable<UID_LENGTH, KW
                         CHAIN_TABLE_KEY_DERIVATION_INFO,
                     );
                     entry_table_value
-                        .next_chain_table_uid::<BLOCK_LENGTH, KMAC_KEY_LENGTH, KmacKey>(kwi_uid);
+                        .next_chain_table_uid::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH, KMAC_KEY_LENGTH, KmacKey>(kwi_uid);
                 })
                 .or_insert_with(|| {
-                    EntryTableValue::new::<BLOCK_LENGTH, KMAC_KEY_LENGTH, KmacKey>(
+                    EntryTableValue::new::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH, KMAC_KEY_LENGTH, KmacKey>(
                         rng,
                         keyword.hash(),
                     )
@@ -469,8 +482,8 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTable<UID_LENGTH, KW
             // Add new indexed values to the chain.
             for indexed_value in indexed_values {
                 entry_table_value.upsert_indexed_value::<
+                    CHAIN_TABLE_WIDTH,
                     BLOCK_LENGTH,
-                    TABLE_WIDTH,
                     KMAC_KEY_LENGTH,
                     DEM_KEY_LENGTH,
                     KmacKey,
@@ -500,8 +513,8 @@ mod tests {
     const UID_LENGTH: usize = 32;
     const KWI_LENGTH: usize = 16;
     const KMAC_KEY_LENGTH: usize = 32;
-    const BLOCK_LENGTH: usize = 32;
-    const TABLE_WIDTH: usize = 2;
+    const BLOCK_LENGTH: usize = 33;
+    const CHAIN_TABLE_WIDTH: usize = 5;
     type KmacKey = Key<KMAC_KEY_LENGTH>;
 
     #[test]
@@ -513,6 +526,7 @@ mod tests {
         let keyword = Keyword::from("Robert".as_bytes());
 
         let entry_table_value = EntryTableValue::<UID_LENGTH, KWI_LENGTH>::new::<
+            CHAIN_TABLE_WIDTH,
             BLOCK_LENGTH,
             KMAC_KEY_LENGTH,
             KmacKey,
@@ -541,6 +555,7 @@ mod tests {
         let keyword = Keyword::from("Robert".as_bytes());
 
         let mut entry_table_value = EntryTableValue::<UID_LENGTH, KWI_LENGTH>::new::<
+            CHAIN_TABLE_WIDTH,
             BLOCK_LENGTH,
             KMAC_KEY_LENGTH,
             KmacKey,
@@ -555,13 +570,13 @@ mod tests {
 
         // Upsert TABLE_WIDTH + 1 values.
         let mut chain_table = EncryptedTable::default();
-        for i in 0..=TABLE_WIDTH {
+        for i in 0..=CHAIN_TABLE_WIDTH {
             let location = Location::from(format!("Robert's location nb {i}").as_bytes());
             let indexed_value = IndexedValue::from(location);
 
             entry_table_value.upsert_indexed_value::<
+                CHAIN_TABLE_WIDTH,
                 BLOCK_LENGTH,
-                TABLE_WIDTH,
                 KMAC_KEY_LENGTH,
                 {Aes256GcmCrypto::KEY_LENGTH},
                 KmacKey,
@@ -570,7 +585,7 @@ mod tests {
         }
 
         let mut kwi_chain_table_uids = KwiChainUids::default();
-        entry_table_value.unchain::<BLOCK_LENGTH, KMAC_KEY_LENGTH, {Aes256GcmCrypto::KEY_LENGTH}, KmacKey, Aes256GcmCrypto>(usize::MAX, &mut kwi_chain_table_uids);
+        entry_table_value.unchain::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH, KMAC_KEY_LENGTH, {Aes256GcmCrypto::KEY_LENGTH}, KmacKey, Aes256GcmCrypto>(usize::MAX, &mut kwi_chain_table_uids);
 
         assert_eq!(kwi_chain_table_uids.len(), 1);
 
@@ -579,12 +594,13 @@ mod tests {
             .iter()
             .filter_map(|uid| chain_table.get(uid))
             .flat_map(|encrypted_chain_table_value| {
-                ChainTableValue::<BLOCK_LENGTH>::decrypt::<
-                    TABLE_WIDTH,
+                ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::decrypt::<
                     { Aes256GcmCrypto::KEY_LENGTH },
                     Aes256GcmCrypto,
                 >(&kwi_value, encrypted_chain_table_value)
                 .unwrap()
+                .as_blocks()
+                .to_vec()
             })
             .collect();
 
@@ -594,7 +610,7 @@ mod tests {
             .into_iter()
             .map(|bytes| IndexedValue::try_from_bytes(&bytes).unwrap());
 
-        assert_eq!(indexed_values.len(), TABLE_WIDTH + 1);
+        assert_eq!(indexed_values.len(), CHAIN_TABLE_WIDTH + 1);
 
         for (i, indexed_value) in indexed_values.enumerate() {
             assert!(indexed_value.is_location());
@@ -621,6 +637,7 @@ mod tests {
         let long_keyword = Keyword::from(long_keyword.as_slice());
 
         let mut entry_table_value = EntryTableValue::<UID_LENGTH, KWI_LENGTH>::new::<
+            CHAIN_TABLE_WIDTH,
             BLOCK_LENGTH,
             KMAC_KEY_LENGTH,
             KmacKey,
@@ -635,8 +652,8 @@ mod tests {
 
         let mut chain_table = EncryptedTable::default();
         entry_table_value.upsert_indexed_value::<
+                CHAIN_TABLE_WIDTH,
                 BLOCK_LENGTH,
-                TABLE_WIDTH,
                 KMAC_KEY_LENGTH,
                 {Aes256GcmCrypto::KEY_LENGTH},
                 KmacKey,
@@ -644,7 +661,7 @@ mod tests {
             >(&long_location, &kwi_uid, &kwi_value, &mut chain_table, &mut rng).unwrap();
 
         let mut kwi_chain_table_uids = KwiChainUids::default();
-        entry_table_value.unchain::<BLOCK_LENGTH, KMAC_KEY_LENGTH, {Aes256GcmCrypto::KEY_LENGTH}, KmacKey, Aes256GcmCrypto>(usize::MAX, &mut kwi_chain_table_uids);
+        entry_table_value.unchain::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH, KMAC_KEY_LENGTH, {Aes256GcmCrypto::KEY_LENGTH}, KmacKey, Aes256GcmCrypto>(usize::MAX, &mut kwi_chain_table_uids);
 
         // Only one keyword is indexed.
         assert_eq!(kwi_chain_table_uids.len(), 1);
@@ -654,16 +671,21 @@ mod tests {
             .iter()
             .filter_map(|uid| chain_table.get(uid))
             .flat_map(|encrypted_chain_table_value| {
-                ChainTableValue::<BLOCK_LENGTH>::decrypt::<
-                    TABLE_WIDTH,
+                ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::decrypt::<
                     { Aes256GcmCrypto::KEY_LENGTH },
                     Aes256GcmCrypto,
                 >(&kwi_value, encrypted_chain_table_value)
                 .unwrap()
+                .as_blocks()
+                .to_vec()
             })
             .collect();
 
+        for block in &blocks {
+            println!("{}: {block:?}", block.data.len());
+        }
         let bytes = Block::<BLOCK_LENGTH>::unpad(&blocks).unwrap();
+        println!("{bytes:?}");
 
         let indexed_values = bytes
             .into_iter()

--- a/src/entry_table.rs
+++ b/src/entry_table.rs
@@ -20,7 +20,7 @@ use crate::{
     chain_table::{ChainTable, ChainTableValue, KwiChainUids},
     error::CoreError as Error,
     keys::KeyCache,
-    structs::{Block, BlockType, EncryptedTable, IndexedValue, Label, Uid},
+    structs::{Block, EncryptedTable, IndexedValue, InsertionType, Label, Uid},
     KeyingMaterial, Keyword, CHAIN_TABLE_KEY_DERIVATION_INFO,
 };
 
@@ -133,7 +133,7 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
                 ChainTableValue::default()
             };
 
-        for block in Block::pad(BlockType::Addition, &indexed_value.to_vec())? {
+        for block in Block::pad(InsertionType::Addition, &indexed_value.to_vec())? {
             if chain_table_value.as_blocks().len() >= CHAIN_TABLE_WIDTH {
                 // Encrypt and insert the current value in the Chain Table.
                 let encrypted_chain_table_value =

--- a/src/entry_table.rs
+++ b/src/entry_table.rs
@@ -20,7 +20,7 @@ use crate::{
     chain_table::{ChainTable, ChainTableValue, KwiChainUids},
     error::CoreError as Error,
     keys::KeyCache,
-    structs::{Block, EncryptedTable, IndexedValue, InsertionType, Label, Uid},
+    structs::{Block, BlockType, EncryptedTable, IndexedValue, Label, Uid},
     KeyingMaterial, Keyword, CHAIN_TABLE_KEY_DERIVATION_INFO,
 };
 
@@ -112,7 +112,7 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
         DemScheme: Dem<DEM_KEY_LENGTH>,
     >(
         &mut self,
-        insertion_type: InsertionType,
+        insertion_type: BlockType,
         indexed_value: &IndexedValue,
         // TODO (TBZ): this should be an `Option` (it can be recomputed from the Entry Table
         // value).
@@ -489,7 +489,7 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTable<UID_LENGTH, KW
                     DEM_KEY_LENGTH,
                     KmacKey,
                     DemScheme
-                >(InsertionType::Addition, indexed_value, kwi_uid, kwi_value, new_chain_table_entries, rng)?;
+                >(BlockType::Addition, indexed_value, kwi_uid, kwi_value, new_chain_table_entries, rng)?;
             }
         }
 
@@ -572,7 +572,7 @@ mod tests {
                 {Aes256GcmCrypto::KEY_LENGTH},
                 KmacKey,
                 Aes256GcmCrypto
-            >(InsertionType::Addition, &indexed_value, &kwi_uid, &kwi_value, &mut chain_table, &mut rng).unwrap();
+            >(BlockType::Addition, &indexed_value, &kwi_uid, &kwi_value, &mut chain_table, &mut rng).unwrap();
         }
 
         // Recover Chain Table UIDs associated to the Entry Table value.
@@ -623,7 +623,7 @@ mod tests {
                 {Aes256GcmCrypto::KEY_LENGTH},
                 KmacKey,
                 Aes256GcmCrypto
-            >(InsertionType::Deletion, &indexed_value, &kwi_uid, &kwi_value, &mut chain_table, &mut rng).unwrap();
+            >(BlockType::Deletion, &indexed_value, &kwi_uid, &kwi_value, &mut chain_table, &mut rng).unwrap();
         }
 
         // Recover Chain Table UIDs associated to the Entry Table value.
@@ -697,7 +697,7 @@ mod tests {
             {Aes256GcmCrypto::KEY_LENGTH},
             KmacKey,
             Aes256GcmCrypto
-        >(InsertionType::Addition, &long_location, &kwi_uid, &kwi_value, &mut chain_table, &mut rng).unwrap();
+        >(BlockType::Addition, &long_location, &kwi_uid, &kwi_value, &mut chain_table, &mut rng).unwrap();
 
         let mut kwi_chain_table_uids = KwiChainUids::default();
         entry_table_value.unchain::<

--- a/src/in_memory_example.rs
+++ b/src/in_memory_example.rs
@@ -101,10 +101,6 @@ impl<const UID_LENGTH: usize> FindexCallbacks<ExampleError, UID_LENGTH>
         &self,
         entry_table_uids: &HashSet<Uid<UID_LENGTH>>,
     ) -> Result<EncryptedTable<UID_LENGTH>, ExampleError> {
-        //println!(
-        //"Fetch {} items from the Entry Table",
-        //entry_table_uids.len()
-        //);
         let mut entry_table_items = EncryptedTable::default();
         for keyword_hash in entry_table_uids {
             if let Some(value) = self.entry_table.get(keyword_hash) {
@@ -118,7 +114,6 @@ impl<const UID_LENGTH: usize> FindexCallbacks<ExampleError, UID_LENGTH>
         &self,
         chain_uids: &HashSet<Uid<UID_LENGTH>>,
     ) -> Result<EncryptedTable<UID_LENGTH>, ExampleError> {
-        //println!("Fetch {} items from the Chain Table", chain_uids.len());
         Ok(chain_uids
             .iter()
             .filter_map(|uid| {
@@ -134,7 +129,6 @@ impl<const UID_LENGTH: usize> FindexCallbacks<ExampleError, UID_LENGTH>
         &mut self,
         modifications: &UpsertData<UID_LENGTH>,
     ) -> Result<EncryptedTable<UID_LENGTH>, ExampleError> {
-        //println!("Upsert {} items in the Entry Table", modifications.len());
         let mut rng = CsRng::from_entropy();
         let mut rejected = EncryptedTable::default();
         // Simulate insertion failures.
@@ -146,7 +140,6 @@ impl<const UID_LENGTH: usize> FindexCallbacks<ExampleError, UID_LENGTH>
                 self.entry_table.insert(uid.clone(), new_value.clone());
             }
         }
-        //println!("{} rejected upsertions", rejected.len());
         Ok(rejected)
     }
 
@@ -154,7 +147,6 @@ impl<const UID_LENGTH: usize> FindexCallbacks<ExampleError, UID_LENGTH>
         &mut self,
         items: &EncryptedTable<UID_LENGTH>,
     ) -> Result<(), ExampleError> {
-        //println!("Insert {} items in the Chain Table", items.len());
         for (uid, value) in items.iter() {
             if self.chain_table.contains_key(uid) {
                 return Err(ExampleError(format!(
@@ -172,19 +164,6 @@ impl<const UID_LENGTH: usize> FindexCallbacks<ExampleError, UID_LENGTH>
         new_encrypted_entry_table_items: EncryptedTable<UID_LENGTH>,
         new_encrypted_chain_table_items: EncryptedTable<UID_LENGTH>,
     ) -> Result<(), ExampleError> {
-        //println!(
-        //"Remove {} items from the Chain Table",
-        //chain_table_uids_to_remove.len()
-        //);
-        //println!(
-        //"Insert {} items to the Chain Table",
-        //new_encrypted_chain_table_items.len()
-        //);
-        //println!(
-        //"Insert {} items to the Entry Table",
-        //new_encrypted_entry_table_items.len()
-        //);
-
         self.entry_table = EncryptedTable::default();
 
         for new_encrypted_entry_table_item in new_encrypted_entry_table_items.iter() {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -164,7 +164,7 @@ macro_rules! impl_findex_search {
             FindexSearch<
                 { $crate::parameters::UID_LENGTH },
                 { $crate::parameters::BLOCK_LENGTH },
-                { $crate::parameters::TABLE_WIDTH },
+                { $crate::parameters::CHAIN_TABLE_WIDTH },
                 { $crate::parameters::MASTER_KEY_LENGTH },
                 { $crate::parameters::KWI_LENGTH },
                 { $crate::parameters::KMAC_KEY_LENGTH },
@@ -185,7 +185,7 @@ macro_rules! impl_findex_upsert {
             FindexUpsert<
                 { $crate::parameters::UID_LENGTH },
                 { $crate::parameters::BLOCK_LENGTH },
-                { $crate::parameters::TABLE_WIDTH },
+                { $crate::parameters::CHAIN_TABLE_WIDTH },
                 { $crate::parameters::MASTER_KEY_LENGTH },
                 { $crate::parameters::KWI_LENGTH },
                 { $crate::parameters::KMAC_KEY_LENGTH },
@@ -206,7 +206,7 @@ macro_rules! impl_findex_compact {
             FindexCompact<
                 { $crate::parameters::UID_LENGTH },
                 { $crate::parameters::BLOCK_LENGTH },
-                { $crate::parameters::TABLE_WIDTH },
+                { $crate::parameters::CHAIN_TABLE_WIDTH },
                 { $crate::parameters::MASTER_KEY_LENGTH },
                 { $crate::parameters::KWI_LENGTH },
                 { $crate::parameters::KMAC_KEY_LENGTH },

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -8,7 +8,7 @@ use cosmian_crypto_core::symmetric_crypto::{aes_256_gcm_pure::Aes256GcmCrypto, k
 pub const UID_LENGTH: usize = 32;
 
 /// Length of the blocks in the Chain Table in bytes.
-pub const BLOCK_LENGTH: usize = 33;
+pub const BLOCK_LENGTH: usize = 32;
 
 /// Number of blocks per Chain Table value.
 pub const TABLE_WIDTH: usize = 5;

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -11,7 +11,7 @@ pub const UID_LENGTH: usize = 32;
 pub const BLOCK_LENGTH: usize = 32;
 
 /// Number of blocks per Chain Table value.
-pub const TABLE_WIDTH: usize = 5;
+pub const CHAIN_TABLE_WIDTH: usize = 5;
 
 /// Length of the Findex master key in bytes.
 pub const MASTER_KEY_LENGTH: usize = 16;

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -11,6 +11,7 @@ pub const UID_LENGTH: usize = 32;
 pub const BLOCK_LENGTH: usize = 32;
 
 /// Number of blocks per Chain Table value.
+/// This parameter should be *smaller* than 8.
 pub const CHAIN_TABLE_WIDTH: usize = 5;
 
 /// Length of the Findex master key in bytes.

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -10,7 +10,7 @@ use crate::{chain_table::ChainTableValue, structs::Block};
 pub const UID_LENGTH: usize = 32;
 
 /// Length of the blocks in the Chain Table in bytes.
-pub const BLOCK_LENGTH: usize = 32;
+pub const BLOCK_LENGTH: usize = 16;
 
 /// Number of blocks per Chain Table value.
 /// This parameter should be *smaller* than 8.

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -4,6 +4,8 @@ use core::num::NonZeroUsize;
 
 use cosmian_crypto_core::symmetric_crypto::{aes_256_gcm_pure::Aes256GcmCrypto, key::Key};
 
+use crate::{chain_table::ChainTableValue, structs::Block};
+
 /// Length of an index table UID in bytes.
 pub const UID_LENGTH: usize = 32;
 
@@ -33,3 +35,14 @@ pub type KmacKey = Key<KMAC_KEY_LENGTH>;
 pub type DemScheme = Aes256GcmCrypto;
 
 pub const SECURE_FETCH_CHAINS_BATCH_SIZE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1) };
+
+/// Checks some constraints on constant generics at compile time.
+pub const fn check_parameter_constraints<
+    const CHAIN_TABLE_WIDTH: usize,
+    const BLOCK_LENGTH: usize,
+>() {
+    #[allow(clippy::let_unit_value)]
+    let _ = ChainTableValue::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>::CHECK_TABLE_WIDTH;
+    #[allow(clippy::let_unit_value)]
+    let _ = Block::<BLOCK_LENGTH>::CHECK_LENGTH;
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -127,9 +127,9 @@ pub trait FindexSearch<
             })?;
             let blocks = chain
                 .into_iter()
-                .flat_map(|(_, chain_table_value)| chain_table_value.as_blocks().to_vec())
+                .flat_map(|(_, chain_table_value)| chain_table_value.into_blocks())
                 .collect::<Vec<_>>();
-            res.insert(keyword.clone(), IndexedValue::from_blocks(blocks)?);
+            res.insert(keyword.clone(), IndexedValue::from_blocks(blocks.iter())?);
         }
         Ok(res)
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -14,7 +14,7 @@ use crate::{
     chain_table::{ChainTableValue, KwiChainUids},
     entry_table::EntryTable,
     error::CallbackError,
-    structs::{Block, IndexedValue, Keyword, Label, Location, Uid},
+    structs::{IndexedValue, Keyword, Label, Location, Uid},
     Error, KeyingMaterial, CHAIN_TABLE_KEY_DERIVATION_INFO, ENTRY_TABLE_KEY_DERIVATION_INFO,
 };
 
@@ -128,8 +128,7 @@ pub trait FindexSearch<
                 .into_iter()
                 .flat_map(|(_, chain_table_value)| chain_table_value.as_blocks().to_vec())
                 .collect::<Vec<_>>();
-            let indexed_values = Block::<BLOCK_LENGTH>::unpad(blocks)?;
-            res.insert(keyword.clone(), indexed_values);
+            res.insert(keyword.clone(), IndexedValue::from_blocks(blocks)?);
         }
         Ok(res)
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -17,7 +17,7 @@ use crate::{
     chain_table::{ChainTableValue, KwiChainUids},
     entry_table::EntryTable,
     error::CallbackError,
-    structs::{Block, IndexedValue, Keyword, Label, Location, Uid},
+    structs::{Block, IndexedValue, InsertionType, Keyword, Label, Location, Uid},
     Error, KeyingMaterial, CHAIN_TABLE_KEY_DERIVATION_INFO, ENTRY_TABLE_KEY_DERIVATION_INFO,
 };
 
@@ -132,8 +132,13 @@ pub trait FindexSearch<
                 .into_iter()
                 .flat_map(|(_, chain_table_value)| chain_table_value.as_blocks().to_vec())
                 .collect::<Vec<_>>();
-            for bytes in Block::unpad(&blocks)? {
-                entry.insert(IndexedValue::try_from_bytes(&bytes)?);
+            for (block_type, bytes) in Block::unpad(&blocks)? {
+                let value = IndexedValue::try_from_bytes(&bytes)?;
+                if InsertionType::Addition == block_type {
+                    entry.insert(value);
+                } else {
+                    entry.remove(&value);
+                }
             }
         }
         Ok(res)

--- a/src/search.rs
+++ b/src/search.rs
@@ -128,7 +128,7 @@ pub trait FindexSearch<
                 .into_iter()
                 .flat_map(|(_, chain_table_value)| chain_table_value.as_blocks().to_vec())
                 .collect::<Vec<_>>();
-            let indexed_values = Block::<BLOCK_LENGTH>::unpad(&blocks)?;
+            let indexed_values = Block::<BLOCK_LENGTH>::unpad(blocks)?;
             res.insert(keyword.clone(), indexed_values);
         }
         Ok(res)

--- a/src/search.rs
+++ b/src/search.rs
@@ -14,6 +14,7 @@ use crate::{
     chain_table::{ChainTableValue, KwiChainUids},
     entry_table::EntryTable,
     error::CallbackError,
+    parameters::check_parameter_constraints,
     structs::{IndexedValue, Keyword, Label, Location, Uid},
     Error, KeyingMaterial, CHAIN_TABLE_KEY_DERIVATION_INFO, ENTRY_TABLE_KEY_DERIVATION_INFO,
 };
@@ -159,6 +160,7 @@ pub trait FindexSearch<
         fetch_chains_batch_size: NonZeroUsize,
         current_depth: usize,
     ) -> Result<HashMap<Keyword, HashSet<Location>>, Error<CustomError>> {
+        check_parameter_constraints::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>();
         // Get indexed values associated to the given keywords
         let res = self
             .non_recursive_search(

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -127,7 +127,18 @@ pub struct Block<const LENGTH: usize> {
     pub(crate) data: [u8; LENGTH],
 }
 
+/// A block length should be a valid `u8` to allow writing in one byte, and the
+/// value `u8::MAX` is reserved to indicate a non-terminating block.
+const MAX_BLOCK_LENGTH: usize = 254; // `u8::MAX - 1`
+
 impl<const LENGTH: usize> Block<LENGTH> {
+    /// This checks that the `BLOCK_LENGTH` does not exceed the
+    /// `MAX_BLOCK_LENGTH`.
+    pub const CHECK_LENGTH: () = assert!(
+        LENGTH <= MAX_BLOCK_LENGTH,
+        "`BLOCK_LENGTH` should be *not* be greater than 254",
+    );
+
     /// Creates a new `Block` from the given bytes. Terminating blocks are
     /// prepended with the number of bytes written and padded with 0s.
     /// Non-terminating blocks are prepended with `LENGTH`.

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -109,7 +109,7 @@ impl From<u8> for BlockPrefix {
 /// prefix value `0` means the block contains no data.
 ///
 /// +-------------------------+--------------------------+
-/// |        1 byte           | `BLOCK_LENGTH` - 1 bytes |
+/// |        1 byte           |      `BLOCK_LENGTH`      |
 /// +-------------------------+--------------------------+
 /// |      `0` or `u8::MAX`   |                          |
 /// |            or           |       padded data        |

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -32,16 +32,24 @@ pub trait FindexUpsert<
     CustomError: std::error::Error + CallbackError,
 >: FindexCallbacks<CustomError, UID_LENGTH>
 {
-    /// Index the given values for the given keywords. After upserting, any
-    /// search for such a keyword will result in finding (at least) the
-    /// corresponding value.
+    /// Index the given added values for the given keywords. Desindex the given
+    /// deleted values for the given keywords.
+    ///
+    /// After upserting, searching for a keyword with added values will result
+    /// in finding (at least) these values. Searching for a keyword with deleted
+    /// values will not result in finding these values.
+    ///
+    /// If a value is indexed for a keyword and desindexed for the same keyword
+    /// in the same upsert operation, the deletion takes precendence over
+    /// the addition.
     ///
     /// # Parameters
     ///
-    /// - `new_chain_elements`  : values to index by keywords
-    /// - `master_key`          : Findex master key
-    /// - `label`               : additional public information used for hashing
-    ///   Entry Table UIDs
+    /// - `additions`   : keywords to index values for
+    /// - `deletions`   : keywords to desindex values for
+    /// - `master_key`  : Findex master key
+    /// - `label`       : additional public information used for hashing Entry
+    ///   Table UIDs
     async fn upsert(
         &mut self,
         additions: HashMap<IndexedValue, HashSet<Keyword>>,

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -21,7 +21,7 @@ use crate::{
 pub trait FindexUpsert<
     const UID_LENGTH: usize,
     const BLOCK_LENGTH: usize,
-    const TABLE_WIDTH: usize,
+    const CHAIN_TABLE_WIDTH: usize,
     const MASTER_KEY_LENGTH: usize,
     const KWI_LENGTH: usize,
     const KMAC_KEY_LENGTH: usize,
@@ -94,8 +94,8 @@ pub trait FindexUpsert<
 
             // Upsert keywords locally.
             let chain_table_additions = entry_table.upsert::<
+                CHAIN_TABLE_WIDTH,
                 BLOCK_LENGTH,
-                TABLE_WIDTH,
                 KMAC_KEY_LENGTH,
                 DEM_KEY_LENGTH,
                 KmacKey,

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -13,6 +13,7 @@ use crate::{
     entry_table::EntryTable,
     error::{CallbackError, Error},
     keys::KeyingMaterial,
+    parameters::check_parameter_constraints,
     structs::{BlockType, EncryptedTable, IndexedValue, Keyword, Label, Uid, UpsertData},
     FindexCallbacks, ENTRY_TABLE_KEY_DERIVATION_INFO,
 };
@@ -48,6 +49,7 @@ pub trait FindexUpsert<
         master_key: &KeyingMaterial<MASTER_KEY_LENGTH>,
         label: &Label,
     ) -> Result<(), Error<CustomError>> {
+        check_parameter_constraints::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>();
         let mut rng = CsRng::from_entropy();
 
         // Revert the `HashMap`.

--- a/tests/test_in_memory.rs
+++ b/tests/test_in_memory.rs
@@ -426,18 +426,13 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
     }
 
     // Try deleting John Doe from the `doe_keyword`.
-    let mut indexed_value_to_keywords = HashMap::new();
-    indexed_value_to_keywords.insert(
+    let mut deletions = HashMap::new();
+    deletions.insert(
         IndexedValue::from(john_doe_location.clone()),
         HashSet::from_iter(vec![doe_keyword.clone()]),
     );
     findex
-        .upsert(
-            HashMap::new(),
-            indexed_value_to_keywords,
-            &master_key,
-            &new_label,
-        )
+        .upsert(HashMap::new(), deletions, &master_key, &new_label)
         .await?;
 
     // Assert John Doe cannot be found by searching for Doe.

--- a/tests/test_in_memory.rs
+++ b/tests/test_in_memory.rs
@@ -475,7 +475,7 @@ async fn test_first_names() -> Result<(), Error<ExampleError>> {
 
     let label = Label::random(&mut rng);
 
-    let file = File::open("tests/first_names.txt").unwrap();
+    let file = File::open("datasets/first_names.txt").unwrap();
     let reader = BufReader::new(file);
     println!("Indexing...");
     for maybe_line in reader.lines() {


### PR DESCRIPTION
Support deleting an indexed value from the list of indexed value of a given keyword.

- the upsert interface now takes as input two distinct lists for the additions and the deletions.
  **Question**: an alternative would be to flag each element of a single list as being an addition or a deletion. I don't know which is the best.
- the Chain Table size is increased by one byte per line.
- the benches have been **improved** (an effort has been made to reduce the overall number of allocations).

Below are given the benches with a comparison to the `feature/add_macros` branch.
```
search/Searching 1 word time:   [10.643 ms 10.676 ms 10.709 ms]
                        change: [-11.934% -11.422% -10.879%] (p = 0.00 < 0.05)
                        Performance has improved.
search/Searching 10 words
                        time:   [10.802 ms 10.832 ms 10.864 ms]
                        change: [-10.606% -10.073% -9.5247%] (p = 0.00 < 0.05)
search/Searching 100 words
                        time:   [11.752 ms 11.790 ms 11.828 ms]
                        change: [-12.358% -11.833% -11.286%] (p = 0.00 < 0.05)
search/Searching 1000 words
                        time:   [21.582 ms 21.630 ms 21.679 ms]
                        change: [-3.1334% -2.7810% -2.4431%] (p = 0.00 < 0.05)
upsert/Indexing 20 keywords
                        time:   [234.91 µs 235.71 µs 236.55 µs]
                        change: [-2.5067% -1.9320% -1.3567%] (p = 0.00 < 0.05)
upsert/Indexing 200 keywords
                        time:   [2.2661 ms 2.2743 ms 2.2828 ms]
                        change: [-8.9163% -8.3586% -7.8004%] (p = 0.00 < 0.05)
upsert/Indexing 2000 keywords
                        time:   [24.211 ms 24.287 ms 24.364 ms]
                        change: [-2.8158% -2.3230% -1.8367%] (p = 0.00 < 0.05)
```