### PR TITLE
feat: insert blocks by batch

### DIFF
--- a/benches/BENCHMARKS.md
+++ b/benches/BENCHMARKS.md
@@ -17,13 +17,13 @@ This is a benchmark comparison report.
 
 |        | `Searching 1 keyword(s)`          | `Searching 10 keyword(s)`          | `Searching 100 keyword(s)`          | `Searching 1000 keyword(s)`           |
 |:-------|:----------------------------------|:-----------------------------------|:------------------------------------|:------------------------------------- |
-|        | `10.04 us` (✅ **1.00x**)          | `90.87 us` (❌ *9.05x slower*)      | `891.55 us` (❌ *88.83x slower*)     | `9.39 ms` (❌ *935.72x slower*)        |
+|        | `10.04 us` (✅ **1.00x**)          | `89.60 us` (❌ *8.92x slower*)      | `886.08 us` (❌ *88.22x slower*)     | `9.26 ms` (❌ *922.18x slower*)        |
 
 ### upsert
 
 |        | `Upserting 10 keyword(s)`          | `Upserting 100 keyword(s)`          | `Upserting 1000 keyword(s)`           |
 |:-------|:-----------------------------------|:------------------------------------|:------------------------------------- |
-|        | `185.01 us` (✅ **1.00x**)          | `1.82 ms` (❌ *9.84x slower*)        | `18.72 ms` (❌ *101.16x slower*)       |
+|        | `188.34 us` (✅ **1.00x**)          | `1.85 ms` (❌ *9.80x slower*)        | `18.66 ms` (❌ *99.06x slower*)        |
 
 ---
 Made with [criterion-table](https://github.com/nu11ptr/criterion-table)

--- a/src/entry_table.rs
+++ b/src/entry_table.rs
@@ -127,25 +127,21 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
                 // - the remaining number of blocks.
                 let n_additions = (CHAIN_TABLE_WIDTH - chain_table_value.as_blocks().len())
                     .min(new_blocks.len() - index);
-                for _ in 0..n_additions {
-                    chain_table_value.try_push(new_blocks[index])?;
-                    index += 1;
-                }
+                chain_table_value.try_pushing_blocks(&new_blocks[index..index + n_additions])?;
+                index += n_additions;
             }
         }
 
         // Add remaining blocks to new lines until exhaustion.
         while index < new_blocks.len() {
-            let n_additions = CHAIN_TABLE_WIDTH.min(new_blocks.len() - index);
             let new_chain_uid = self
                 .next_chain_table_uid::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH, KMAC_KEY_LENGTH, KmacKey>(
                     kwi_uid,
                 );
             let mut new_chain_value = ChainTableValue::default();
-            for _ in 0..n_additions {
-                new_chain_value.try_push(new_blocks[index])?;
-                index += 1;
-            }
+            let n_additions = CHAIN_TABLE_WIDTH.min(new_blocks.len() - index);
+            new_chain_value.try_pushing_blocks(&new_blocks[index..index + n_additions])?;
+            index += n_additions;
             let old_value = chain_table.insert(new_chain_uid.clone(), new_chain_value);
             if old_value.is_some() {
                 return Err(Error::CryptoError(format!(


### PR DESCRIPTION
When writting blocks to Chain Table values, write as many blocks as possible by batch using `copy_from_slice` (one `mem_copy` call).

This allows unexpected perf gains:

```
upsert/Indexing 20 keywords
                        time:   [233.29 µs 234.45 µs 235.62 µs]
                        change: [-0.0958% +0.5225% +1.0567%] (p = 0.08 > 0.05)

upsert/Indexing 200 keywords
                        time:   [2.2100 ms 2.2207 ms 2.2316 ms]
                        change: [-2.4507% -1.8761% -1.2349%] (p = 0.00 < 0.05)

upsert/Indexing 2000 keywords
                        time:   [20.495 ms 20.550 ms 20.605 ms]
                        change: [-14.570% -14.235% -13.909%] (p = 0.00 < 0.05)
```