### PR TITLE
fix: remove calls to `HashMap::remove()`

### DIFF
--- a/benches/BENCHMARKS.md
+++ b/benches/BENCHMARKS.md
@@ -17,13 +17,13 @@ This is a benchmark comparison report.
 
 |        | `Searching 1 keyword(s)`          | `Searching 10 keyword(s)`          | `Searching 100 keyword(s)`          | `Searching 1000 keyword(s)`           |
 |:-------|:----------------------------------|:-----------------------------------|:------------------------------------|:------------------------------------- |
-|        | `11.07 us` (✅ **1.00x**)          | `101.23 us` (❌ *9.14x slower*)     | `1.03 ms` (❌ *92.98x slower*)       | `10.81 ms` (❌ *976.12x slower*)       |
+|        | `11.18 us` (✅ **1.00x**)          | `99.07 us` (❌ *8.86x slower*)      | `1.01 ms` (❌ *90.42x slower*)       | `10.85 ms` (❌ *970.72x slower*)       |
 
 ### upsert
 
 |        | `Upserting 10 keyword(s)`          | `Upserting 100 keyword(s)`          | `Upserting 1000 keyword(s)`           |
 |:-------|:-----------------------------------|:------------------------------------|:------------------------------------- |
-|        | `178.06 us` (✅ **1.00x**)          | `1.81 ms` (❌ *10.19x slower*)       | `18.49 ms` (❌ *103.83x slower*)       |
+|        | `180.68 us` (✅ **1.00x**)          | `1.80 ms` (❌ *9.95x slower*)        | `18.24 ms` (❌ *100.95x slower*)       |
 
 ---
 Made with [criterion-table](https://github.com/nu11ptr/criterion-table)

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -208,7 +208,7 @@ pub trait FetchChains<
         // Collect to a `HashSet` to mix UIDs between chains.
         let chain_table_uids = kwi_chain_table_uids.values().flatten().cloned().collect();
 
-        let mut encrypted_items = self.fetch_chain_table(chain_table_uids).await?;
+        let encrypted_items = self.fetch_chain_table(chain_table_uids).await?;
 
         let mut res = HashMap::with_capacity(kwi_chain_table_uids.len());
         for (kwi, chain_table_uids) in kwi_chain_table_uids.into_iter() {
@@ -219,9 +219,9 @@ pub trait FetchChains<
             let mut chain = Vec::with_capacity(chain_table_uids.len());
 
             for uid in chain_table_uids {
-                let (uid, encrypted_value) =
+                let encrypted_value =
                     encrypted_items
-                        .remove_entry(&uid)
+                        .get(&uid)
                         .ok_or(Error::<CustomError>::CryptoError(format!(
                             "no Chain Table entry with UID '{uid:?}' in fetch result",
                         )))?;
@@ -229,7 +229,7 @@ pub trait FetchChains<
                     uid,
                     ChainTableValue::decrypt::<DEM_KEY_LENGTH, DemScheme>(
                         &kwi_value,
-                        &encrypted_value,
+                        encrypted_value,
                     )?,
                 ));
             }


### PR DESCRIPTION
Rust `HashMap` implementation is based on the SwissTable algorithm, which is optimized for insert and read operations. Thus for small values, it may is preferable to `get()` and `clone()` rather than `remove()`.

The following benchmarks show that removing a `HashMap` entry in order to get the value stored without copy is about 18% slower than getting this value and then to copy it.

There seems to be no time difference between small values of sizes 32 or 64B.

```
Deletion
                        time:   [99.916 ns 101.47 ns 103.25 ns]

Get + clone / value length: 32B
                        time:   [84.808 ns 86.263 ns 88.109 ns]

Get + clone / value length: 64B
                        time:   [84.844 ns 86.027 ns 87.410 ns]
```

Plus, I would argue that using `get()` is less prone to introduce errors when modifying the code since it is not possible to search for a removed value. It also simplifies the reading.