### PR TITLE
fix: simplify the Findex search algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ in_memory = []
 live_compact = []
 
 [dependencies]
-async-recursion = "1.0.0"
 cosmian_crypto_core = "7.0.0"
 futures = "0.3"
 rand = "0.8"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -61,7 +61,7 @@ fn bench_search(c: &mut Criterion) {
         let keywords = prepare_keywords(n_keywords);
         group.bench_function(format!("Searching {n_keywords} keyword(s)"), |b| {
             b.iter(|| {
-                block_on(findex.search(&master_key, &label, &keywords, usize::MAX, usize::MAX))
+                block_on(findex.search(&master_key, &label, keywords.clone(), usize::MAX))
                     .expect("search failed");
             });
         });

--- a/examples/search.rs
+++ b/examples/search.rs
@@ -52,7 +52,7 @@ fn main() {
     //
     let keywords = prepare_keywords(1000);
     for _ in 0..1000 {
-        block_on(findex.search(&master_key, &label, &keywords, usize::MAX, usize::MAX))
+        block_on(findex.search(&master_key, &label, keywords.clone(), usize::MAX))
             .expect("search failed");
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -2,7 +2,6 @@
 
 use std::collections::{HashMap, HashSet};
 
-use async_recursion::async_recursion;
 use cosmian_crypto_core::symmetric_crypto::{Dem, SymKey};
 
 use crate::{
@@ -40,11 +39,8 @@ pub trait FindexSearch<
         CustomError,
     >
 {
-    /// Searches for a set of keywords, returning the corresponding indexed
-    /// values.
-    ///
-    /// *Note*: An `IndexedValue` can be either a `Location` or another
-    /// `Keyword`.
+    /// Searches for a set of `Keyword`s, returning the corresponding
+    /// `IndexedValue`s.
     ///
     /// # Parameters
     ///
@@ -61,10 +57,6 @@ pub trait FindexSearch<
         keywords: &HashSet<Keyword>,
         max_uid_per_chain: usize,
     ) -> Result<HashMap<Keyword, HashSet<IndexedValue>>, Error<CustomError>> {
-        if keywords.is_empty() {
-            return Ok(HashMap::new());
-        }
-
         // Derive Entry Table UIDs from keywords.
         let entry_table_uid_map = keywords
             .iter()
@@ -128,91 +120,61 @@ pub trait FindexSearch<
         Ok(res)
     }
 
-    /// Recursively searches Findex indexes to build the graph of the given
+    /// Iteratively searches Findex indexes to build the graphs of the given
     /// keywords.
     ///
-    /// For given recursion level:
-    /// - search Findex for the given keywords
+    /// For a given iteration:
+    /// - search Findex for the targeted keywords
     /// - add these keywords with their indexed locations to the known graph
-    /// - if the maximum recursion level is reached or a user interruption is
-    ///   received through the `progress` callback, ignore the next keywords;
-    ///   otherwise add them to the results of the associated keyword in the
-    ///   graph and mark the unknown keywords for the next recursion
-    /// - if there are some new keywords to search, call this function with
-    ///   these new keywords as input
+    /// - if a user interruption is received through the `progress` callback,
+    ///   ignore the next keywords; otherwise mark them as targets for the next
+    ///   recursion
     ///
     /// # Parameters
     ///
-    /// - `k_uid`               : KMAC key used to generate Entry Table UIDs
-    /// - `k_value`             : DEM key used to decrypt the Entry Table
+    /// - `master_key`          : Findex master secret key
     /// - `label`               : public label used for hashing
     /// - `keywords`            : keywords to search using Findex
-    /// - `graph`               : known keyword graph
-    /// - `max_depth`           : maximum recursion level allowed
-    /// - `current_depth`       : current depth reached by the recursion
     /// - `max_uid_per_chain`   : maximum number of UIDs to compute per keyword
-    #[async_recursion(?Send)]
-    #[allow(clippy::too_many_arguments)]
-    async fn recursive_search(
+    async fn iterative_search(
         &mut self,
-        k_uid: &KmacKey,
-        k_value: &DemScheme::Key,
+        master_key: &KeyingMaterial<MASTER_KEY_LENGTH>,
         label: &Label,
-        keywords: &HashSet<Keyword>,
-        graph: &mut HashMap<Keyword, HashSet<IndexedValue>>,
-        max_depth: usize,
-        current_depth: usize,
+        mut keywords: HashSet<Keyword>,
         max_uid_per_chain: usize,
-    ) -> Result<(), Error<CustomError>> {
-        let current_results = self
-            .core_search(k_uid, k_value, label, keywords, max_uid_per_chain)
-            .await?;
+    ) -> Result<HashMap<Keyword, HashSet<IndexedValue>>, Error<CustomError>> {
+        let k_uid = master_key.derive_kmac_key(ENTRY_TABLE_KEY_DERIVATION_INFO);
+        let k_value = master_key.derive_dem_key(ENTRY_TABLE_KEY_DERIVATION_INFO);
 
-        let continue_recursion = self.progress(&current_results).await?;
+        let mut graph = HashMap::with_capacity(keywords.len());
 
-        let mut next_keywords = HashSet::with_capacity(current_results.len());
-        for (keyword, indexed_values) in current_results {
-            if continue_recursion && current_depth != max_depth {
-                // Mark unknown keywords to be searched in the next recursion.
-                next_keywords.extend(
-                    indexed_values
-                        .iter()
-                        .filter_map(|value| value.get_keyword())
-                        .filter(|next_keyword| !graph.contains_key(next_keyword))
-                        .cloned(),
-                );
-                // Add all indexed values to the results.
-                graph.insert(keyword, indexed_values);
-            } else {
-                // Do not add the next keyword to the results.
-                graph.insert(
-                    keyword,
-                    indexed_values
-                        .into_iter()
-                        .filter(|value| value.is_location())
-                        .collect(),
-                );
+        // Since keywords cannot be requested twice, the number of iterations can only
+        // be smaller than the greatest depth of the searched keyword graphs.
+        while !keywords.is_empty() {
+            let results = self
+                .core_search(&k_uid, &k_value, label, &keywords, max_uid_per_chain)
+                .await?;
+
+            // Return early in case of user interrupt.
+            let is_continue = self.progress(&results).await?;
+
+            if is_continue {
+                keywords = results
+                    .values()
+                    .flat_map(|indexed_values| {
+                        indexed_values
+                            .iter()
+                            .filter_map(|value| value.get_keyword())
+                            .filter(|next_keyword| !graph.contains_key(*next_keyword))
+                            .cloned()
+                    })
+                    .collect();
             }
+
+            graph.extend(results);
         }
 
-        // Recurse if some keywords still need to be searched. An empty `next_keyword`
-        // set means that there is no more keywords to search, that the user interrupted
-        // the search or that the recursion has reached the maximum depth allowed.
-        if !next_keywords.is_empty() {
-            self.recursive_search(
-                k_uid,
-                k_value,
-                label,
-                &next_keywords,
-                graph,
-                max_depth,
-                current_depth + 1,
-                max_uid_per_chain,
-            )
-            .await?;
-        }
-
-        Ok(())
+        Ok(graph)
     }
 
     /// Searches for the `Location`s indexed by the given `Keyword`s. This is
@@ -229,39 +191,25 @@ pub trait FindexSearch<
         &mut self,
         master_key: &KeyingMaterial<MASTER_KEY_LENGTH>,
         label: &Label,
-        keywords: &HashSet<Keyword>,
-        max_depth: usize,
+        keywords: HashSet<Keyword>,
         max_uid_per_chain: usize,
     ) -> Result<HashMap<Keyword, HashSet<Location>>, Error<CustomError>> {
         check_parameter_constraints::<CHAIN_TABLE_WIDTH, BLOCK_LENGTH>();
 
-        let k_uid = master_key.derive_kmac_key(ENTRY_TABLE_KEY_DERIVATION_INFO);
-        let k_value = master_key.derive_dem_key(ENTRY_TABLE_KEY_DERIVATION_INFO);
-
         // Search Findex indexes to build the keyword graph.
-        let mut graph = HashMap::with_capacity(keywords.len());
-        self.recursive_search(
-            &k_uid,
-            &k_value,
-            label,
-            keywords,
-            &mut graph,
-            max_depth,
-            0,
-            max_uid_per_chain,
-        )
-        .await?;
+        let graph = self
+            .iterative_search(master_key, label, keywords.clone(), max_uid_per_chain)
+            .await?;
 
         // Walk the graph to get the results.
-        let mut results = HashMap::with_capacity(keywords.len());
-        for keyword in keywords {
-            results.insert(
-                keyword.clone(),
-                self.walk_graph_from(keyword, &graph, &mut HashSet::new())?,
-            );
-        }
-
-        Ok(results)
+        keywords
+            .into_iter()
+            .map(|keyword| -> Result<_, _> {
+                let keyword_results =
+                    self.walk_graph_from(&keyword, &graph, &mut HashSet::new())?;
+                Ok((keyword, keyword_results))
+            })
+            .collect()
     }
 
     /// Retrives the `Location`s stored in the given graph for the given

--- a/tests/test_in_memory.rs
+++ b/tests/test_in_memory.rs
@@ -15,7 +15,6 @@ use cosmian_findex::{
 use rand::Rng;
 
 const MIN_KEYWORD_LENGTH: usize = 3;
-const MAX_DEPTH: usize = 100;
 const MAX_UID_PER_CHAIN: usize = usize::MAX;
 
 /// Converts the given strings as a `HashSet` of Keywords.
@@ -126,8 +125,7 @@ async fn test_progress_callack() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([robert_keyword.clone()]),
-            usize::MAX,
+            HashSet::from_iter([robert_keyword.clone()]),
             usize::MAX,
         )
         .await?;
@@ -138,24 +136,11 @@ async fn test_progress_callack() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &Label::random(&mut rng),
-            &HashSet::from_iter([robert_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([robert_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
     assert_eq!(robert_search.get(&robert_keyword), Some(&HashSet::new()));
-
-    // search rob without graph search
-    let rob_search = findex
-        .search(
-            &master_key,
-            &label,
-            &HashSet::from_iter([rob_keyword.clone()]),
-            1,
-            MAX_UID_PER_CHAIN,
-        )
-        .await?;
-    check_search_result(&rob_search, &rob_keyword, &rob_location);
 
     // search rob with graph search
     findex.check_progress_callback_next_keyword = true;
@@ -163,8 +148,7 @@ async fn test_progress_callack() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([rob_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([rob_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -230,8 +214,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([robert_keyword.clone()]),
-            usize::MAX,
+            HashSet::from_iter([robert_keyword.clone()]),
             usize::MAX,
         )
         .await?;
@@ -242,8 +225,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &Label::random(&mut rng),
-            &HashSet::from_iter([robert_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([robert_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -254,8 +236,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([doe_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([doe_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -267,8 +248,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([rob_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([rob_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -279,8 +259,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([rob_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([rob_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -313,8 +292,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([jane_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([jane_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -325,8 +303,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([robert_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([robert_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -337,8 +314,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([doe_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([doe_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -351,8 +327,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([rob_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([rob_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -376,8 +351,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
             .search(
                 &master_key,
                 &new_label,
-                &HashSet::from_iter([doe_keyword.clone()]),
-                MAX_DEPTH,
+                HashSet::from_iter([doe_keyword.clone()]),
                 MAX_UID_PER_CHAIN,
             )
             .await?;
@@ -399,8 +373,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &new_label,
-            &HashSet::from_iter([jane_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([jane_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -412,8 +385,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &new_label,
-            &HashSet::from_iter([doe_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([doe_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -425,8 +397,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([doe_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([doe_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -447,8 +418,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &new_label,
-            &HashSet::from_iter([doe_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([doe_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -460,8 +430,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([doe_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([doe_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -480,8 +449,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
             .search(
                 &master_key,
                 &new_label,
-                &HashSet::from_iter([doe_keyword.clone()]),
-                MAX_DEPTH,
+                HashSet::from_iter([doe_keyword.clone()]),
                 MAX_UID_PER_CHAIN,
             )
             .await?;
@@ -504,8 +472,7 @@ async fn test_findex() -> Result<(), Error<ExampleError>> {
         .search(
             &master_key,
             &new_label,
-            &HashSet::from_iter([doe_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([doe_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await?;
@@ -630,7 +597,7 @@ async fn test_first_names() -> Result<(), Error<ExampleError>> {
     for s in searches {
         let keywords = HashSet::from_iter([Keyword::from(s.as_str())]);
         let graph_results = graph_findex
-            .search(&master_key, &label, &keywords, MAX_DEPTH, MAX_UID_PER_CHAIN)
+            .search(&master_key, &label, keywords.clone(), MAX_UID_PER_CHAIN)
             .await?;
         assert!(
             !graph_results.is_empty(),
@@ -639,7 +606,7 @@ async fn test_first_names() -> Result<(), Error<ExampleError>> {
         total_results += graph_results.len();
         // naive search
         let naive_results = naive_findex
-            .search(&master_key, &label, &keywords, MAX_DEPTH, MAX_UID_PER_CHAIN)
+            .search(&master_key, &label, keywords, MAX_UID_PER_CHAIN)
             .await?;
         assert_eq!(
             graph_results.len(),
@@ -705,8 +672,7 @@ async fn test_graph_compacting() {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([rob_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([rob_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await
@@ -745,8 +711,7 @@ async fn test_graph_compacting() {
             .search(
                 &master_key,
                 &label,
-                &HashSet::from_iter([rob_keyword.clone()]),
-                MAX_DEPTH,
+                HashSet::from_iter([rob_keyword.clone()]),
                 MAX_UID_PER_CHAIN,
             )
             .await
@@ -818,8 +783,7 @@ async fn test_live_compacting() {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([robert_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([robert_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await
@@ -832,8 +796,7 @@ async fn test_live_compacting() {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([doe_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([doe_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await
@@ -997,8 +960,7 @@ async fn test_search_cyclic_graph() {
         .search(
             &master_key,
             &label,
-            &HashSet::from_iter([a_keyword.clone(), i_keyword.clone()]),
-            MAX_DEPTH,
+            HashSet::from_iter([a_keyword.clone(), i_keyword.clone()]),
             MAX_UID_PER_CHAIN,
         )
         .await


### PR DESCRIPTION
- remove the recursion
- remove unnecessary filter on the graph insertions
- remove the `max_depth` parameter: avoiding looping on automate cycles is enough to ensure the algorithm will return; an early return can still be asked by the user via the `progress()` callback
- use iterators where possible

This implementations uses one more clone of the input keywords. However, since a useless clone from the previous implementation has been removed, there should be the same nomber of clones in both versions.