### PR TITLE
Allow multiple chains for one keyword

### DIFF
--- a/src/core/entry_table.rs
+++ b/src/core/entry_table.rs
@@ -139,7 +139,8 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
                 // Encrypt and insert the current value in the Chain Table.
                 let encrypted_chain_table_value = chain_table_value
                     .encrypt::<TABLE_WIDTH, DEM_KEY_LENGTH, DemScheme>(kwi_value, rng)?;
-                chain_table.insert(self.chain_table_uid.clone(), encrypted_chain_table_value);
+                chain_table
+                    .replace_or_push(self.chain_table_uid.clone(), encrypted_chain_table_value);
                 // Start a new line in the chain.
                 self.next_chain_table_uid::<BLOCK_LENGTH, KMAC_KEY_LENGTH, KmacKey>(kwi_uid);
                 chain_table_value = ChainTableValue::new::<TABLE_WIDTH>(vec![block])?;
@@ -149,7 +150,7 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTableValue<UID_LENGT
         // Encrypt and insert the value in the Chain Table.
         let encrypted_chain_table_value =
             chain_table_value.encrypt::<TABLE_WIDTH, DEM_KEY_LENGTH, DemScheme>(kwi_value, rng)?;
-        chain_table.insert(self.chain_table_uid.clone(), encrypted_chain_table_value);
+        chain_table.replace_or_push(self.chain_table_uid.clone(), encrypted_chain_table_value);
         Ok(())
     }
 
@@ -372,7 +373,7 @@ impl<const UID_LENGTH: usize, const KWI_LENGTH: usize> EntryTable<UID_LENGTH, KW
     ) -> Result<EncryptedTable<UID_LENGTH>, FindexErr> {
         let mut encrypted_entry_table = EncryptedTable::with_capacity(self.len());
         for (k, v) in self.iter() {
-            encrypted_entry_table.insert(
+            encrypted_entry_table.replace_or_push(
                 k.clone(),
                 EntryTableValue::<UID_LENGTH, KWI_LENGTH>::encrypt::<
                     BLOCK_LENGTH,

--- a/src/core/upsert.rs
+++ b/src/core/upsert.rs
@@ -120,7 +120,7 @@ pub trait FindexUpsert<
 
             for (keyword, uid) in &entry_table_uid_cache {
                 // Remove chains that have successfully been upserted.
-                if !encrypted_entry_table.contains_key(uid) {
+                if !encrypted_entry_table.contains_uid(uid) {
                     new_chain_elements.remove_entry(keyword);
                 }
             }
@@ -149,7 +149,7 @@ pub trait FindexUpsert<
         let encrypted_entry_table = self.upsert_entry_table(&entry_table_modifications).await?;
 
         // Insert new Chain Table lines.
-        chain_table_additions.retain(|uid, _| !encrypted_entry_table.contains_key(uid));
+        chain_table_additions.retain(|uid, _| !encrypted_entry_table.contains_uid(uid));
         let new_chain_table_entries = chain_table_additions.into_values().flatten().collect();
 
         self.insert_chain_table(&new_chain_table_entries).await?;

--- a/src/interfaces/pyo3/py_api.rs
+++ b/src/interfaces/pyo3/py_api.rs
@@ -100,16 +100,16 @@ impl FindexCallbacks<UID_LENGTH> for InternalFindex {
                 .fetch_entry
                 .call1(py, (py_entry_uids,))
                 .map_err(|e| FindexErr::CallBack(format!("{e} (fetch_entry)")))?;
-            let py_result_table: HashMap<[u8; UID_LENGTH], Vec<u8>> = results
+            let py_result_table: Vec<([u8; UID_LENGTH], Vec<u8>)> = results
                 .extract(py)
                 .map_err(|e| FindexErr::ConversionError(format!("{e} (fetch_entry)")))?;
 
-            // Convert python result (HashMap<[u8; UID_LENGTH], Vec<u8>>) to
+            // Convert python result (Vec<([u8; UID_LENGTH], Vec<u8>)>) to
             // EncryptedEntryTable<UID_LENGTH>
             let entry_table_items = py_result_table
                 .into_iter()
                 .map(|(k, v)| (Uid::from(k), v))
-                .collect::<HashMap<_, _>>();
+                .collect::<Vec<_>>();
 
             Ok(entry_table_items.into())
         })
@@ -130,16 +130,16 @@ impl FindexCallbacks<UID_LENGTH> for InternalFindex {
                 .call1(py, (py_chain_uids,))
                 .map_err(|e| FindexErr::CallBack(format!("{e} (fetch_chain)")))?;
 
-            let py_result_table: HashMap<[u8; UID_LENGTH], Vec<u8>> = result
+            let py_result_table: Vec<([u8; UID_LENGTH], Vec<u8>)> = result
                 .extract(py)
                 .map_err(|e| FindexErr::ConversionError(format!("{e} (fetch_chain)")))?;
 
-            // Convert python result (HashMap<[u8; UID_LENGTH], Vec<u8>>) to
+            // Convert python result (Vec<([u8; UID_LENGTH], Vec<u8>)>) to
             // EncryptedTable<UID_LENGTH>
             let chain_table_items = py_result_table
                 .into_iter()
                 .map(|(k, v)| (Uid::from(k), v))
-                .collect::<HashMap<_, _>>();
+                .collect::<Vec<_>>();
             Ok(chain_table_items.into())
         })
     }
@@ -168,14 +168,14 @@ impl FindexCallbacks<UID_LENGTH> for InternalFindex {
                 .call1(py, (py_entry_table,))
                 .map_err(|e| FindexErr::CallBack(format!("{e} (upsert_entry)")))?;
 
-            let rejected_lines: HashMap<[u8; UID_LENGTH], Vec<u8>> = rejected_lines
+            let rejected_lines: Vec<([u8; UID_LENGTH], Vec<u8>)> = rejected_lines
                 .extract(py)
                 .map_err(|e| FindexErr::ConversionError(format!("{e} (upsert_entry)")))?;
 
             let rejected_lines = rejected_lines
                 .into_iter()
                 .map(|(k, v)| (Uid::from(k), v))
-                .collect::<HashMap<_, _>>();
+                .collect::<Vec<_>>();
 
             Ok(rejected_lines.into())
         })

--- a/src/interfaces/sqlite/findex.rs
+++ b/src/interfaces/sqlite/findex.rs
@@ -54,7 +54,7 @@ impl FindexCallbacks<UID_LENGTH> for RusqliteFindex<'_> {
         let mut chain_table_items = EncryptedTable::default();
         while let Some(row) = rows.next()? {
             let uid: Vec<u8> = row.get(0)?;
-            chain_table_items.insert(Uid::try_from_bytes(&uid)?, row.get(1)?);
+            chain_table_items.replace_or_push(Uid::try_from_bytes(&uid)?, row.get(1)?);
         }
         Ok(chain_table_items)
     }
@@ -79,7 +79,7 @@ impl FindexCallbacks<UID_LENGTH> for RusqliteFindex<'_> {
                     [uid.to_vec(), new_value.clone()],
                 )?;
             } else {
-                rejected_items.insert(
+                rejected_items.replace_or_push(
                     uid.clone(),
                     actual_value.ok_or_else(|| {
                         FindexErr::CallBack(

--- a/src/interfaces/sqlite/utils.rs
+++ b/src/interfaces/sqlite/utils.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use cosmian_crypto_core::bytes_ser_de::Serializable;
 use rusqlite::{Connection, Statement};
 
@@ -51,12 +49,12 @@ pub fn sqlite_fetch_entry_table_items(
     let mut stmt = prepare_statement(connection, serialized_entry_uids, "entry_table")?;
 
     let mut rows = stmt.raw_query();
-    let mut entry_table_items = HashMap::new();
+    let mut entry_table_items = Vec::new();
     while let Some(row) = rows.next()? {
-        entry_table_items.insert(
+        entry_table_items.push((
             Uid::try_from_bytes(&row.get::<usize, Vec<u8>>(0)?)?,
             row.get(1)?,
-        );
+        ));
     }
     EncryptedTable::<UID_LENGTH>::from(entry_table_items).try_to_bytes()
 }

--- a/src/interfaces/wasm_bindgen/core/utils.rs
+++ b/src/interfaces/wasm_bindgen/core/utils.rs
@@ -112,7 +112,7 @@ pub fn js_value_to_encrypted_table<const UID_LENGTH: usize>(
         let uid = get_bytes_from_object_property(&obj, "uid", &object_source_for_errors, i)?;
 
         let value = get_bytes_from_object_property(&obj, "value", &object_source_for_errors, i)?;
-        encrypted_table.insert(
+        encrypted_table.push((
             Uid::try_from_bytes(&uid).map_err(|e| {
                 FindexErr::CallBack(format!(
                     "cannot parse the `uid` returned by `{callback_name_for_errors}` at position \
@@ -121,7 +121,7 @@ pub fn js_value_to_encrypted_table<const UID_LENGTH: usize>(
                 ))
             })?,
             value.clone(),
-        );
+        ));
     }
     Ok(encrypted_table)
 }


### PR DESCRIPTION
- [ ] fix `contains_uid` and `get` method not optimized for `Vec`
- [ ] is it better to allow only entries to be duplicated and not chains?