### PR TITLE
Fix/alloc problem with multi values in fetch entry tables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ name: Cloudproof build
 on:
   push:
     tags:
-      - "*"
+      - '*'
   pull_request:
 
 jobs:
@@ -15,9 +15,9 @@ jobs:
       toolchain: nightly-2023-03-20
       kms-version: 4.0.1
       regression-filename: sqlite.db
-      branch-java: multi_values_fetch_entry_table
-      branch-js: multi_values_fetch_entry_table
-      branch-flutter: multi_values_fetch_entry_table
+      branch-java: fix/alloc_problem_with_multi_values_in_fetch_entry_tables
+      branch-js: v6.0.4
+      branch-flutter: fix/alloc_problem_with_multi_values_in_fetch_entry_tables
       branch-python: python_not_tested
       bench-features: sqlite
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ jniLibs
 *.svg
 perf.data*
 *dataset.json
+Cargo.lock
+sqlite_bench.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.0.3] - 2023-05-16
+## [2.0.4] - 2023-05-23
 
-**This version follows the 2.0.0 since the 2.0.1 version introduced breaking changes we didn't want to include.**
+### Bug Fixes
+
+- Add entry table number in FFI functions in order to pre-allocate the output buffer size in fetching callbacks
+
+## [2.0.3] - 2023-05-16
 
 ### Features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmian_findex"
-version = "2.0.3"
+version = "2.0.4"
 authors = [
   "Chloé Hébant <chloe.hebant@cosmian.com>",
   "Bruno Grieder <bruno.grieder@cosmian.com>",

--- a/src/core/compact.rs
+++ b/src/core/compact.rs
@@ -38,7 +38,7 @@ pub trait FindexCompact<
 {
     /// Replaces all the Index Entry Table UIDs and values. New UIDs are derived
     /// using the given label and the KMAC key derived from the new master key.
-    /// The values are dectypted using the DEM key derived from the master key
+    /// The values are decrypted using the DEM key derived from the master key
     /// and re-encrypted using the DEM key derived from the new master key.
     ///
     /// Randomly selects index entries and recompact their associated chains.

--- a/src/core/search.rs
+++ b/src/core/search.rs
@@ -50,6 +50,7 @@ pub trait FindexSearch<
     /// - `label`                   : public label
     /// - `max_results_per_keyword` : maximum number of results to return per
     ///   keyword
+    /// - `fetch_chains_batch_size` : maximum number of chains fetched in batch
     async fn non_recursive_search(
         &mut self,
         keywords: &HashSet<Keyword>,

--- a/src/interfaces/ffi/api.rs
+++ b/src/interfaces/ffi/api.rs
@@ -44,7 +44,6 @@ use crate::{
 /// - `max_depth`               : maximum recursion depth allowed
 /// - `fetch_chains_batch_size` : maximum number of chains fetched in batch
 /// - `entry_table_number`      : number of different entry tables
-
 /// - `progress_callback`       : callback used to retrieve intermediate results
 ///   and transmit user interrupt
 ///  - `fetch_entry`            : the callback function to fetch the values from

--- a/src/interfaces/ffi/api.rs
+++ b/src/interfaces/ffi/api.rs
@@ -29,9 +29,7 @@ use crate::{
             error::{set_last_error, FfiErr},
             MAX_DEPTH,
         },
-        generic_parameters::{
-            MASTER_KEY_LENGTH, MAX_RESULTS_PER_KEYWORD, SECURE_FETCH_CHAINS_BATCH_SIZE,
-        },
+        generic_parameters::{MAX_RESULTS_PER_KEYWORD, SECURE_FETCH_CHAINS_BATCH_SIZE},
         ser_de::SerializableSet,
     },
 };
@@ -44,6 +42,9 @@ use crate::{
 ///  - `max_results_per_keyword`: maximum number of results to return per
 ///    keyword
 /// - `max_depth`               : maximum recursion depth allowed
+/// - `fetch_chains_batch_size` : maximum number of chains fetched in batch
+/// - `entry_table_number`      : number of different entry tables
+
 /// - `progress_callback`       : callback used to retrieve intermediate results
 ///   and transmit user interrupt
 ///  - `fetch_entry`            : the callback function to fetch the values from
@@ -58,14 +59,14 @@ async fn ffi_search(
     max_results_per_keyword: usize,
     max_depth: usize,
     fetch_chains_batch_size: NonZeroUsize,
+    entry_table_number: usize,
     progress: ProgressCallback,
     fetch_entry: FetchEntryTableCallback,
     fetch_chain: FetchChainTableCallback,
 ) -> Result<Vec<u8>, FindexErr> {
-    let master_key = KeyingMaterial::<MASTER_KEY_LENGTH>::try_from_bytes(master_key_bytes)
-        .map_err(|e| {
-            FindexErr::Other(format!("While parsing master key for Findex search, {e}"))
-        })?;
+    let master_key = KeyingMaterial::try_from_bytes(master_key_bytes).map_err(|e| {
+        FindexErr::Other(format!("While parsing master key for Findex search, {e}"))
+    })?;
     let label = Label::from(label_bytes);
 
     let mut keywords = HashSet::with_capacity(base64_keywords.len());
@@ -80,6 +81,7 @@ async fn ffi_search(
     }
 
     let mut ffi_search = FindexUser {
+        entry_table_number,
         progress: Some(progress),
         fetch_entry: Some(fetch_entry),
         fetch_chain: Some(fetch_chain),
@@ -152,6 +154,7 @@ pub unsafe extern "C" fn h_search(
     max_results_per_keyword: c_int,
     max_depth: c_int,
     fetch_chains_batch_size: c_uint,
+    entry_table_number: c_uint,
     progress_callback: ProgressCallback,
     fetch_entry: FetchEntryTableCallback,
     fetch_chain: FetchChainTableCallback,
@@ -173,7 +176,7 @@ pub unsafe extern "C" fn h_search(
     } else {
         ffi_unwrap!(
             usize::try_from(max_results_per_keyword),
-            "loop_iteration_limit must be a positive int"
+            "max_results_per_keyword must be a positive int"
         )
     };
 
@@ -182,7 +185,7 @@ pub unsafe extern "C" fn h_search(
     } else {
         ffi_unwrap!(
             usize::try_from(max_depth),
-            "loop_iteration_limit must be a positive int"
+            "max_depth must be a positive int"
         )
     };
 
@@ -220,6 +223,10 @@ pub unsafe extern "C" fn h_search(
         .and_then(NonZeroUsize::new)
         .unwrap_or(SECURE_FETCH_CHAINS_BATCH_SIZE);
 
+    if entry_table_number == 0 {
+        ffi_bail!("The parameter entry_table_number must be strictly positive. Found 0");
+    }
+
     let serialized_uids = ffi_unwrap!(executor::block_on(ffi_search(
         &base64_keywords,
         master_key_bytes,
@@ -227,6 +234,7 @@ pub unsafe extern "C" fn h_search(
         max_results_per_keyword,
         max_depth,
         fetch_chains_batch_size,
+        entry_table_number as usize,
         progress_callback,
         fetch_entry,
         fetch_chain,
@@ -273,13 +281,17 @@ pub unsafe extern "C" fn h_search(
 ///
 /// # Parameters
 ///
-/// - `master_key`      : Findex master key
-/// - `label`           : additional information used to derive Entry Table UIDs
+/// - `master_key`                  : Findex master key
+/// - `label`                       : additional information used to derive
+///   Entry Table UIDs
 /// - `indexed_values_and_keywords` : serialized list of values and the keywords
 ///   used to index them
-/// - `fetch_entry`     : callback used to fetch the Entry Table
-/// - `upsert_entry`    : callback used to upsert lines in the Entry Table
-/// - `insert_chain`    : callback used to insert lines in the Chain Table
+/// - `entry_table_number`          : number of different entry tables
+/// - `fetch_entry`                 : callback used to fetch the Entry Table
+/// - `upsert_entry`                : callback used to upsert lines in the Entry
+///   Table
+/// - `insert_chain`                : callback used to insert lines in the Chain
+///   Table
 ///
 /// # Safety
 ///
@@ -290,6 +302,7 @@ pub unsafe extern "C" fn h_upsert(
     label_ptr: *const u8,
     label_len: c_int,
     indexed_values_and_keywords_ptr: *const c_char,
+    entry_table_number: c_uint,
     fetch_entry: FetchEntryTableCallback,
     upsert_entry: UpsertEntryTableCallback,
     insert_chain: InsertChainTableCallback,
@@ -299,7 +312,7 @@ pub unsafe extern "C" fn h_upsert(
     ffi_not_null!(master_key_ptr, "Master Key pointer should not be null");
     let master_key_bytes = slice::from_raw_parts(master_key_ptr, master_key_len as usize);
     let master_key = ffi_unwrap!(
-        KeyingMaterial::<MASTER_KEY_LENGTH>::try_from_bytes(master_key_bytes).map_err(|e| {
+        KeyingMaterial::try_from_bytes(master_key_bytes).map_err(|e| {
             FindexErr::Other(format!("while parsing master key for Findex upsert, {e}"))
         })
     );
@@ -326,6 +339,11 @@ pub unsafe extern "C" fn h_upsert(
                 return 1;
             }
         };
+
+    if entry_table_number == 0 {
+        ffi_bail!("The parameter entry_table_number must be strictly positive. Found 0");
+    }
+
     // a map of base64 encoded `IndexedValue` to a list of base64 encoded keyWords
     let parsed_indexed_values_and_keywords = ffi_unwrap!(serde_json::from_str::<
         HashMap<String, Vec<String>>,
@@ -348,6 +366,7 @@ pub unsafe extern "C" fn h_upsert(
     // Finally write indexes in database
     //
     let mut ffi_upsert = FindexUser {
+        entry_table_number: entry_table_number as usize,
         progress: None,
         fetch_entry: Some(fetch_entry),
         fetch_chain: None,
@@ -370,7 +389,7 @@ pub unsafe extern "C" fn h_upsert(
 #[no_mangle]
 /// Replaces all the Index Entry Table UIDs and values. New UIDs are derived
 /// using the given label and the KMAC key derived from the new master key. The
-/// values are dectypted using the DEM key derived from the master key and
+/// values are decrypted using the DEM key derived from the master key and
 /// re-encrypted using the DEM key derived from the new master key.
 ///
 /// Randomly selects index entries and recompact their associated chains. Chains
@@ -386,7 +405,8 @@ pub unsafe extern "C" fn h_upsert(
 /// - `old_master_key`                  : old Findex master key
 /// - `new_master_key`                  : new Findex master key
 /// - `label`                           : additional information used to derive
-///   Entry Table UIDs
+/// - `entry_table_number`              : number of different entry table Entry
+///   Table UIDs
 /// - `fetch_entry`                     : callback used to fetch the Entry Table
 /// - `fetch_chain`                     : callback used to fetch the Chain Table
 /// - `update_lines`                    : callback used to update lines in both
@@ -405,6 +425,7 @@ pub unsafe extern "C" fn h_compact(
     new_master_key_len: c_int,
     label_ptr: *const u8,
     label_len: c_int,
+    entry_table_number: c_uint,
     fetch_all_entry_table_uids: FetchAllEntryTableUidsCallback,
     fetch_entry: FetchEntryTableCallback,
     fetch_chain: FetchChainTableCallback,
@@ -426,24 +447,24 @@ pub unsafe extern "C" fn h_compact(
     // Parse master Key
     ffi_not_null!(master_key_ptr, "Master Key pointer should not be null");
     let master_key_bytes = slice::from_raw_parts(master_key_ptr, master_key_len as usize);
-    let master_key = ffi_unwrap!(KeyingMaterial::<MASTER_KEY_LENGTH>::try_from_bytes(
-        master_key_bytes
-    ));
+    let master_key = ffi_unwrap!(KeyingMaterial::try_from_bytes(master_key_bytes));
     let new_master_key_bytes =
         slice::from_raw_parts(new_master_key_ptr, new_master_key_len as usize);
-    let new_master_key = ffi_unwrap!(KeyingMaterial::<MASTER_KEY_LENGTH>::try_from_bytes(
-        new_master_key_bytes
-    ));
+    let new_master_key = ffi_unwrap!(KeyingMaterial::try_from_bytes(new_master_key_bytes));
 
     ffi_not_null!(label_ptr, "Label pointer should not be null");
 
     let label_bytes = slice::from_raw_parts(label_ptr, label_len as usize);
     let label = Label::from(label_bytes);
 
+    if entry_table_number == 0 {
+        ffi_bail!("The parameter entry_table_number must be strictly positive. Found 0");
+    }
     //
     // Finally write indexes in database
     //
     let mut ffi_compact = FindexUser {
+        entry_table_number: entry_table_number as usize,
         progress: None,
         fetch_entry: Some(fetch_entry),
         fetch_chain: Some(fetch_chain),

--- a/src/interfaces/ffi/core/mod.rs
+++ b/src/interfaces/ffi/core/mod.rs
@@ -18,7 +18,7 @@ pub const NUMBER_OF_ENTRY_TABLE_LINE_IN_BATCH: usize = 100;
 /// Other error codes will be forwarded to the client as a response to
 /// the main call error code so that the client can report some custom
 /// callbacks errors (for example the Flutter lib is using 42 to report
-/// an expection during a callback, save this exception and re-report this
+/// an exception during a callback, save this exception and re-report this
 /// exception at the end of the main call if the response is 42).
 pub enum ErrorCode {
     Success = 0,
@@ -33,6 +33,7 @@ pub enum ErrorCode {
 
 /// Implements Findex traits.
 pub struct FindexUser {
+    pub(crate) entry_table_number: usize,
     pub(crate) progress: Option<ProgressCallback>,
     pub(crate) fetch_all_entry_table_uids: Option<FetchAllEntryTableUidsCallback>,
     pub(crate) fetch_entry: Option<FetchEntryTableCallback>,

--- a/src/interfaces/ffi/core/traits.rs
+++ b/src/interfaces/ffi/core/traits.rs
@@ -71,7 +71,10 @@ impl FindexCallbacks<UID_LENGTH> for FindexUser {
         let serialized_uids = serialize_set(entry_table_uids)?;
         let res = fetch_callback(
             &serialized_uids,
-            get_serialized_encrypted_entry_table_size_bound(entry_table_uids.len()),
+            get_serialized_encrypted_entry_table_size_bound(
+                entry_table_uids.len(),
+                self.entry_table_number,
+            ),
             *fetch_entry,
             "fetch entries",
         )?;
@@ -104,7 +107,10 @@ impl FindexCallbacks<UID_LENGTH> for FindexUser {
         let serialized_upsert_data = modifications.try_to_bytes()?;
 
         // Callback output
-        let allocation_size = get_serialized_encrypted_entry_table_size_bound(modifications.len());
+        let allocation_size = get_serialized_encrypted_entry_table_size_bound(
+            modifications.len(),
+            self.entry_table_number,
+        );
         let mut serialized_rejected_items = vec![0; allocation_size];
         let mut serialized_rejected_items_len = allocation_size as u32;
         let serialized_rejected_items_ptr =

--- a/src/interfaces/ffi/core/utils.rs
+++ b/src/interfaces/ffi/core/utils.rs
@@ -46,15 +46,21 @@ macro_rules! unwrap_callback {
 ///
 /// # Arguments
 /// - `line_number` : number of lines in the encrypted Entry Table
-pub const fn get_serialized_encrypted_entry_table_size_bound(line_number: usize) -> usize {
-    LEB128_MAXIMUM_ENCODED_BYTES_NUMBER
+/// - `entry_table_number` : number of different entry tables. The number is
+///   required here since severable entry table could give multiple results
+pub const fn get_serialized_encrypted_entry_table_size_bound(
+    line_number: usize,
+    entry_table_number: usize,
+) -> usize {
+    (LEB128_MAXIMUM_ENCODED_BYTES_NUMBER
         + line_number * UID_LENGTH
         + line_number
             * (LEB128_MAXIMUM_ENCODED_BYTES_NUMBER
                 + DemScheme::ENCRYPTION_OVERHEAD
                 + KWI_LENGTH
                 + UID_LENGTH
-                + Keyword::HASH_LENGTH)
+                + Keyword::HASH_LENGTH))
+        * entry_table_number
 }
 
 /// Returns an upper-bound on the size of a serialized encrypted Chain Table.

--- a/src/interfaces/ffi/core/utils.rs
+++ b/src/interfaces/ffi/core/utils.rs
@@ -52,15 +52,15 @@ pub const fn get_serialized_encrypted_entry_table_size_bound(
     line_number: usize,
     entry_table_number: usize,
 ) -> usize {
-    (LEB128_MAXIMUM_ENCODED_BYTES_NUMBER
-        + line_number * UID_LENGTH
+    LEB128_MAXIMUM_ENCODED_BYTES_NUMBER
         + line_number
-            * (LEB128_MAXIMUM_ENCODED_BYTES_NUMBER
+            * entry_table_number
+            * (UID_LENGTH
+                + LEB128_MAXIMUM_ENCODED_BYTES_NUMBER
                 + DemScheme::ENCRYPTION_OVERHEAD
                 + KWI_LENGTH
                 + UID_LENGTH
-                + Keyword::HASH_LENGTH))
-        * entry_table_number
+                + Keyword::HASH_LENGTH)
 }
 
 /// Returns an upper-bound on the size of a serialized encrypted Chain Table.

--- a/src/interfaces/wasm_bindgen/api.rs
+++ b/src/interfaces/wasm_bindgen/api.rs
@@ -10,9 +10,7 @@ use super::core::search_results_to_js;
 use crate::{
     core::{FindexSearch, FindexUpsert, KeyingMaterial, Keyword, Label},
     interfaces::{
-        generic_parameters::{
-            MASTER_KEY_LENGTH, MAX_RESULTS_PER_KEYWORD, SECURE_FETCH_CHAINS_BATCH_SIZE,
-        },
+        generic_parameters::{MAX_RESULTS_PER_KEYWORD, SECURE_FETCH_CHAINS_BATCH_SIZE},
         wasm_bindgen::core::{
             to_indexed_values_to_keywords, ArrayOfKeywords, Fetch, FindexUser,
             IndexedValuesAndWords, Insert, Progress, SearchResults, Upsert,
@@ -29,6 +27,7 @@ use crate::{
 /// - `keywords`                : list of keyword bytes to search
 /// - `max_results_per_keyword` : maximum results returned for a keyword
 /// - `max_depth`               : maximum recursion level allowed
+/// - `fetch_chains_batch_size` : maximum number of chains fetched in batch
 /// - `progress`                : progress callback
 /// - `fetch_entries`           : callback to fetch from the Entry Table
 /// - `fetch_chains`            : callback to fetch from the Chain Table
@@ -45,7 +44,7 @@ pub async fn webassembly_search(
     fetch_entry: Fetch,
     fetch_chain: Fetch,
 ) -> Result<SearchResults, JsValue> {
-    let master_key = KeyingMaterial::<MASTER_KEY_LENGTH>::try_from_bytes(&master_key.to_vec())
+    let master_key = KeyingMaterial::try_from_bytes(&master_key.to_vec())
         .map_err(|e| JsValue::from(format!("While parsing master key for Findex search, {e}")))?;
     let label = Label::from(label_bytes.to_vec());
 
@@ -110,7 +109,7 @@ pub async fn webassembly_upsert(
     upsert_entry: Upsert,
     insert_chain: Insert,
 ) -> Result<(), JsValue> {
-    let master_key = KeyingMaterial::<MASTER_KEY_LENGTH>::try_from_bytes(&master_key.to_vec())
+    let master_key = KeyingMaterial::try_from_bytes(&master_key.to_vec())
         .map_err(|e| JsValue::from(format!("While parsing master key for Findex upsert, {e}")))?;
     let label = Label::from(label_bytes.to_vec());
     let indexed_values_to_keywords = to_indexed_values_to_keywords(&indexed_values_to_keywords)?;


### PR DESCRIPTION
## [2.0.4] - 2023-05-23

### Bug Fixes

- Add entry table number in FFI functions in order to pre-allocate the output buffer size in fetching callbacks

