### PR TITLE
Fix/relax async req

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- use `#[async_trait(?Send)]`
+
 ## [5.0.2] - 2023-09-07
 
 ### Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cosmian_findex"
-version = "5.0.2"
+version = "5.0.3"
 authors = [
   "Chloé Hébant <chloe.hebant@cosmian.com>",
   "Bruno Grieder <bruno.grieder@cosmian.com>",

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Trait implementing all callbacks needed by Findex.
-#[async_trait]
+#[async_trait(?Send)]
 pub trait FindexCallbacks<Error: std::error::Error + CallbackError, const UID_LENGTH: usize> {
     /// Returns partial results during a search. Stops the search if the
     /// returned value is `false`. This can be useful to stop the search when an
@@ -179,7 +179,7 @@ pub trait FindexCallbacks<Error: std::error::Error + CallbackError, const UID_LE
     async fn delete_chain(&mut self, uids: Uids<UID_LENGTH>) -> Result<(), Error>;
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait FetchChains<
     const UID_LENGTH: usize,
     const BLOCK_LENGTH: usize,

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -20,7 +20,7 @@ use crate::{
 /// The compact operation is required to remove old indexes from the Index
 /// Chain Table and to improve the security of the index by changing all the
 /// Index Entry Table.
-#[async_trait]
+#[async_trait(?Send)]
 pub trait FindexCompact<
     const UID_LENGTH: usize,
     const BLOCK_LENGTH: usize,

--- a/src/in_memory_example.rs
+++ b/src/in_memory_example.rs
@@ -122,7 +122,7 @@ impl<const UID_LENGTH: usize> FindexInMemory<UID_LENGTH> {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl<const UID_LENGTH: usize> FindexCallbacks<ExampleError, UID_LENGTH>
     for FindexInMemory<UID_LENGTH>
 {

--- a/src/search.rs
+++ b/src/search.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Trait implementing the search functionality of Findex.
-#[async_trait]
+#[async_trait(?Send)]
 pub trait FindexSearch<
     const UID_LENGTH: usize,
     const BLOCK_LENGTH: usize,

--- a/src/upsert.rs
+++ b/src/upsert.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 /// This the public trait exposed to the users of the Findex Upsert API.
-#[async_trait]
+#[async_trait(?Send)]
 pub trait FindexUpsert<
     const UID_LENGTH: usize,
     const BLOCK_LENGTH: usize,


### PR DESCRIPTION
Using `#[async_trait]` enforce trait member outputs to implement `Send`, which is not possible when working with WASM in CloudproofRust.

Using `#[async_trait(?Send)]` allows relaxing this constraint.