### PR TITLE
extract memory encryption: pass an encrypted memory to Findex::new

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: datasets|tests_data|documentation/Findex.pdf|tests/first_names.txt
+exclude: benches/data|benches/make_figures.tex
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v2.1.1
@@ -118,20 +118,21 @@ repos:
         args: [--skip-string-normalization]
 
   - repo: https://github.com/Cosmian/git-hooks.git
-    rev: v1.0.16
+    rev: v1.0.36
     hooks:
       - id: stable-cargo-format
-      - id: cargo-upgrade
-      - id: cargo-update
+      # - id: dprint-toml-fix
+      # - id: cargo-upgrade
+      # - id: cargo-update
       - id: cargo-machete
-      - id: cargo-outdated
-      - id: cargo-udeps
+      - id: redis-container-up
       - id: cargo-tests-all
       - id: cargo-test-doc
-      - id: clippy-autofix-all
-      - id: clippy-autofix-pedantic
-      - id: clippy-autofix-others
+      - id: clippy-autofix-all-targets-all-features
+      - id: clippy-autofix-all-targets
       - id: clippy-all-targets-all-features
+      - id: clippy-all-targets
       - id: stable-cargo-format
       - id: cargo-dry-publish
         args: [--allow-dirty]
+      - id: redis-container-down

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ test-utils = []
 
 [dependencies]
 aes = "0.8.4"
-rand = "0.8.5"
-rand_chacha = "0.3.1"
-rand_core = "0.6.4"
-redis = { version = "0.28.1", features = [
+rand = "0.9.0"
+rand_chacha = "0.9.0"
+rand_core = "0.9.0"
+redis = { version = "0.28.2", features = [
     "aio",
     "connection-manager",
     "tokio-comp",
@@ -40,9 +40,9 @@ zeroize = { version = "1.8.1", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.5.1"
-futures = "0.3.30"
+futures = "0.3.31"
 lazy_static = "1.5.0"
-tokio = { version = "1.38.0", features = [
+tokio = { version = "1.43.0", features = [
     "macros",
     "rt",
     "rt-multi-thread",

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,7 +4,7 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             Cosmian Tech SAS.
-Licensed Work:        Cosmian KMS version 4.11.3 or later.
+Licensed Work:        Cosmian Findex version 6.0.0 or later.
                       The Licensed Work is (c) 2024 Cosmian Tech SAS.
 Additional Use Grant: You may use the Licensed Work in production, provided
                       your total use of does not exceed a total of 4 vCPUS on virtual

--- a/examples/insert.rs
+++ b/examples/insert.rs
@@ -1,6 +1,6 @@
 //! This example show-cases the use of Findex to securely store a hash-map.
 
-use cosmian_findex::{Findex, InMemory, IndexADT, Op, Secret};
+use cosmian_findex::{Findex, InMemory, IndexADT, MemoryEncryptionLayer, Op, Secret};
 use futures::executor::block_on;
 use rand_chacha::ChaChaRng;
 use rand_core::{CryptoRngCore, SeedableRng};
@@ -100,16 +100,16 @@ fn main() {
     // trait. It corresponds to an in-memory key-value store implemented on top
     // of a hash-table. For real application a DB such as Redis would be
     // preferred.
-    let memory = InMemory::default();
+    let memory = MemoryEncryptionLayer::new(&key, InMemory::default());
 
     // Instantiating Findex requires passing the key, the memory used and the
     // encoder and decoder. Quite simple, after all :)
     let findex = Findex::<
-        WORD_LENGTH,    // size of a word
-        u64,            // type of a value
-        String,         // type of an encoding error
-        InMemory<_, _>, // type of the memory
-    >::new(&key, memory, encoder, decoder);
+        WORD_LENGTH, // size of a word
+        u64,         // type of a value
+        String,      // type of an encoding error
+        _,           // type of the memory
+    >::new(memory, encoder, decoder);
 
     // Here we insert all bindings one by one, blocking on each call. A better
     // way would be to performed all such calls in parallel using tasks.

--- a/examples/insert.rs
+++ b/examples/insert.rs
@@ -3,7 +3,7 @@
 use cosmian_findex::{Findex, InMemory, IndexADT, MemoryEncryptionLayer, Op, Secret};
 use futures::executor::block_on;
 use rand_chacha::ChaChaRng;
-use rand_core::{CryptoRngCore, SeedableRng};
+use rand_core::{CryptoRng, SeedableRng};
 use std::collections::{HashMap, HashSet};
 
 /// This function generates a random set of (key, values) couples. Since Findex
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 /// associated *keyword* of type `[u8; 8]` in this example. Since Findex only
 /// requires from the values to be hashable, we could have taken any type that
 /// implements `Hash` instead of the `u64`.
-fn gen_index(rng: &mut impl CryptoRngCore) -> HashMap<[u8; 8], HashSet<u64>> {
+fn gen_index(rng: &mut impl CryptoRng) -> HashMap<[u8; 8], HashSet<u64>> {
     (0..6)
         .map(|i| {
             let kw = rng.next_u64().to_be_bytes();
@@ -86,7 +86,7 @@ fn decoder(words: Vec<[u8; WORD_LENGTH]>) -> Result<HashSet<u64>, String> {
 fn main() {
     // For cryptographic applications, it is important to use a secure RNG. In
     // Rust, those RNG implement the `CryptoRng` trait.
-    let mut rng = ChaChaRng::from_entropy();
+    let mut rng = ChaChaRng::from_os_rng();
 
     // Generate fresh Findex key. In practice only one user is in charge of
     // generating the key (the administrator?): all users *must* share the same

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Deref, DerefMut};
 
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 // NOTE: a more efficient implementation of the address could be a big-int.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -39,7 +39,7 @@ impl<const LENGTH: usize> Default for Address<LENGTH> {
 }
 
 impl<const LENGTH: usize> Address<LENGTH> {
-    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
+    pub fn random(rng: &mut impl CryptoRng) -> Self {
         let mut res = Self([0; LENGTH]);
         rng.fill_bytes(&mut *res);
         res

--- a/src/adt/interfaces.rs
+++ b/src/adt/interfaces.rs
@@ -7,7 +7,7 @@
 
 use std::{collections::HashSet, future::Future, hash::Hash};
 
-/// An index stores *bindings*, that associate a keyword with a value. All values bound to the same
+/// An index stores *values*, that associate a keyword with a value. All values bound to the same
 /// keyword are said to be *indexed under* this keyword.
 pub trait IndexADT<Keyword: Send + Sync + Hash, Value: Send + Sync + Hash> {
     type Error: Send + Sync + std::error::Error;
@@ -18,18 +18,18 @@ pub trait IndexADT<Keyword: Send + Sync + Hash, Value: Send + Sync + Hash> {
         keyword: &Keyword,
     ) -> impl Future<Output = Result<HashSet<Value>, Self::Error>>;
 
-    /// Adds the given bindings to the index.
+    /// Adds the given values to the index.
     fn insert(
         &self,
-        kw: Keyword,
-        bindings: impl Sync + Send + IntoIterator<Item = Value>,
+        keyword: Keyword,
+        values: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> impl Send + Future<Output = Result<(), Self::Error>>;
 
-    /// Removes the given bindings from the index.
+    /// Removes the given values from the index.
     fn delete(
         &self,
-        kw: Keyword,
-        bindings: impl Sync + Send + IntoIterator<Item = Value>,
+        keyword: Keyword,
+        values: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> impl Send + Future<Output = Result<(), Self::Error>>;
 }
 
@@ -43,7 +43,7 @@ pub trait VectorADT: Send + Sync {
     /// Pushes the given values at the end of this vector.
     fn push(
         &mut self,
-        vs: Vec<Self::Value>,
+        values: Vec<Self::Value>,
     ) -> impl Send + Future<Output = Result<(), Self::Error>>;
 
     /// Reads all values stored in this vector.
@@ -64,7 +64,7 @@ pub trait MemoryADT {
     /// Reads the words from the given addresses.
     fn batch_read(
         &self,
-        a: Vec<Self::Address>,
+        addresses: Vec<Self::Address>,
     ) -> impl Send + Future<Output = Result<Vec<Option<Self::Word>>, Self::Error>>;
 
     /// Write the given words at the given addresses if the word currently stored at the guard
@@ -72,7 +72,7 @@ pub trait MemoryADT {
     fn guarded_write(
         &self,
         guard: (Self::Address, Option<Self::Word>),
-        tasks: Vec<(Self::Address, Self::Word)>,
+        bindings: Vec<(Self::Address, Self::Word)>,
     ) -> impl Send + Future<Output = Result<Option<Self::Word>, Self::Error>>;
 }
 

--- a/src/adt/test_utils.rs
+++ b/src/adt/test_utils.rs
@@ -8,25 +8,42 @@
 //!
 //! Both addresses and words are 16-byte long.
 
-use crate::MemoryADT;
-use rand::{Rng, RngCore, SeedableRng, rngs::StdRng};
+use crate::{ADDRESS_LENGTH, KEY_LENGTH, MemoryADT};
+use rand::{RngCore, SeedableRng, rngs::StdRng};
 use std::fmt::Debug;
 
-fn gen_bytes(rng: &mut impl RngCore) -> [u8; 16] {
-    let mut bytes = [0; 16];
+fn gen_bytes<const BYTES_LENGTH: usize>(rng: &mut impl RngCore) -> [u8; BYTES_LENGTH] {
+    let mut bytes = [0; BYTES_LENGTH];
     rng.fill_bytes(&mut bytes);
     bytes
+}
+
+fn u128_to_array<const WORD_LENGTH: usize>(u: u128) -> [u8; WORD_LENGTH] {
+    let mut bytes = [0u8; WORD_LENGTH];
+    bytes[..16].copy_from_slice(&u.to_be_bytes());
+    bytes
+}
+
+fn word_to_array<const WORD_LENGTH: usize>(word: [u8; WORD_LENGTH]) -> Result<u128, &'static str> {
+    if WORD_LENGTH < 16 {
+        return Err("WORD_LENGTH must be at least 16 bytes");
+    }
+    let mut bytes = [0; 16];
+    bytes.copy_from_slice(&word[..16]);
+    Ok(u128::from_be_bytes(bytes))
 }
 
 /// Tests the basic write and read operations of a Memory ADT implementation.
 ///
 /// This function first attempts reading empty addresses, then performing a
 /// guarded write, and finally validating the written value.
-pub async fn test_single_write_and_read<Memory>(memory: &Memory, seed: [u8; 32])
-where
+pub async fn test_single_write_and_read<const WORD_LENGTH: usize, Memory>(
+    memory: &Memory,
+    seed: [u8; KEY_LENGTH],
+) where
     Memory: Send + Sync + MemoryADT,
-    Memory::Address: Send + Clone + From<[u8; 16]>,
-    Memory::Word: Send + Debug + Clone + PartialEq + From<[u8; 16]>,
+    Memory::Address: Send + Clone + From<[u8; ADDRESS_LENGTH]>,
+    Memory::Word: Send + Debug + Clone + PartialEq + From<[u8; WORD_LENGTH]>,
     Memory::Error: std::error::Error,
 {
     let mut rng = StdRng::from_seed(seed);
@@ -67,11 +84,13 @@ where
 ///
 /// Attempts to write with a None guard to an address containing a value.
 /// Verifies that the original value is preserved and the write fails.
-pub async fn test_wrong_guard<Memory>(memory: &Memory, seed: [u8; 32])
-where
+pub async fn test_wrong_guard<const WORD_LENGTH: usize, Memory>(
+    memory: &Memory,
+    seed: [u8; KEY_LENGTH],
+) where
     Memory: Send + Sync + MemoryADT,
-    Memory::Address: Send + Clone + From<[u8; 16]>,
-    Memory::Word: Send + Debug + Clone + PartialEq + From<[u8; 16]>,
+    Memory::Address: Send + Clone + From<[u8; ADDRESS_LENGTH]>,
+    Memory::Word: Send + Debug + Clone + PartialEq + From<[u8; WORD_LENGTH]>,
     Memory::Error: Send + std::error::Error,
 {
     let mut rng = StdRng::from_seed(seed);
@@ -87,7 +106,7 @@ where
     let conflict_result = memory
         .guarded_write((a.clone(), None), vec![(
             a.clone(),
-            Memory::Word::from(rng.gen::<u128>().to_be_bytes()),
+            Memory::Word::from(gen_bytes(&mut rng)),
         )])
         .await
         .unwrap();
@@ -118,11 +137,14 @@ where
 /// Spawns multiple threads to perform concurrent counter increments.
 /// Uses retries to handle write contention between threads.
 /// Verifies the final counter matches the total number of threads.
-pub async fn test_guarded_write_concurrent<Memory>(memory: &Memory, seed: [u8; 32])
-where
+pub async fn test_guarded_write_concurrent<const WORD_LENGTH: usize, Memory>(
+    memory: &Memory,
+    seed: [u8; KEY_LENGTH],
+) where
     Memory: 'static + Send + Sync + MemoryADT + Clone,
-    Memory::Address: Send + From<[u8; 16]>,
-    Memory::Word: Send + Debug + PartialEq + From<[u8; 16]> + Into<[u8; 16]> + Clone + Default,
+    Memory::Address: Send + From<[u8; ADDRESS_LENGTH]>,
+    Memory::Word:
+        Send + Debug + PartialEq + From<[u8; WORD_LENGTH]> + Into<[u8; WORD_LENGTH]> + Clone,
     Memory::Error: Send + std::error::Error,
 {
     {
@@ -131,25 +153,25 @@ where
         let a = gen_bytes(&mut rng);
 
         // A worker increment N times the counter m[a].
-        let worker = |m: Memory, a: [u8; 16]| async move {
+        let worker = |m: Memory, a: [u8; ADDRESS_LENGTH]| async move {
             let mut cnt = 0u128;
             for _ in 0..N {
                 loop {
                     let guard = if 0 == cnt {
                         None
                     } else {
-                        Some(Memory::Word::from(cnt.to_be_bytes()))
+                        Some(Memory::Word::from(u128_to_array(cnt)))
                     };
 
                     let new_cnt = cnt + 1;
                     let cur_cnt = m
                         .guarded_write((a.into(), guard), vec![(
                             a.into(),
-                            Memory::Word::from(new_cnt.to_be_bytes()),
+                            Memory::Word::from(u128_to_array(new_cnt)),
                         )])
                         .await
                         .unwrap()
-                        .map(|w| <u128>::from_be_bytes(w.into()))
+                        .map(|w| word_to_array(w.into()).unwrap())
                         .unwrap_or_default();
 
                     if cnt == cur_cnt {
@@ -179,12 +201,12 @@ where
             .expect("Counter should exist");
 
         assert_eq!(
-            u128::from_be_bytes(final_count.clone().into()),
+            word_to_array(final_count.clone().into()).unwrap(),
             (N * N) as u128,
             "test_guarded_write_concurrent failed. Expected the counter to be at {:?}, found \
              {:?}.\nDebug seed : {:?}.",
             N as u128,
-            u128::from_be_bytes(final_count.into()),
+            word_to_array(final_count.into()).unwrap(),
             seed
         );
     }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -264,10 +264,12 @@ pub mod generic_encoding {
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod tests {
-    use crate::{Decoder, Encoder, Op};
+    use crate::Op;
 
     use rand::{RngCore, thread_rng};
     use std::{collections::HashSet, fmt::Debug, hash::Hash};
+
+    use super::{Decoder, Encoder};
 
     /// Uses fuzzing to attempt asserting that: encode ∘ decode = identity.
     ///

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -237,13 +237,13 @@ pub mod generic_encoding {
 
     #[cfg(test)]
     mod tests {
-        use rand::{RngCore, thread_rng};
+        use rand::{RngCore, rng};
 
         use super::*;
 
         #[test]
         fn test_metadata_encoding() {
-            let mut rng = thread_rng();
+            let mut rng = rng();
             for _ in 0..1000 {
                 let op = if rng.next_u32() % 2 == 1 {
                     Op::Insert
@@ -266,7 +266,7 @@ pub mod generic_encoding {
 pub mod tests {
     use crate::Op;
 
-    use rand::{RngCore, thread_rng};
+    use rand::{RngCore, rng};
     use std::{collections::HashSet, fmt::Debug, hash::Hash};
 
     use super::{Decoder, Encoder};
@@ -300,7 +300,7 @@ pub mod tests {
         encode: Encoder<Value, Word, EncodingError>,
         decode: Decoder<Value, Word, EncodingError>,
     ) {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         // Draws a random number of operations in [0,100].
         let n_ops = rng.next_u32() % 10;

--- a/src/findex.rs
+++ b/src/findex.rs
@@ -74,11 +74,11 @@ impl<
     async fn push<Keyword: Send + Sync + Hash + Eq>(
         &self,
         op: Op,
-        kw: Keyword,
-        vs: HashSet<Value>,
+        keyword: Keyword,
+        values: HashSet<Value>,
     ) -> Result<(), <Self as IndexADT<Keyword, Value>>::Error> {
-        let words = (self.encode)(op, vs).map_err(|e| Error::Conversion(format!("{e:?}")))?;
-        let l = Self::hash_keyword(&kw);
+        let words = (self.encode)(op, values).map_err(|e| Error::Conversion(format!("{e:?}")))?;
+        let l = Self::hash_keyword(&keyword);
         IVec::new(l, self.el.clone()).push(words).await
     }
 }
@@ -93,26 +93,28 @@ impl<
 {
     type Error = Error<Address<ADDRESS_LENGTH>>;
 
-    async fn search(&self, kw: &Keyword) -> Result<HashSet<Value>, Self::Error> {
-        let l = Self::hash_keyword(kw);
+    async fn search(&self, keyword: &Keyword) -> Result<HashSet<Value>, Self::Error> {
+        let l = Self::hash_keyword(keyword);
         let words = IVec::new(l, self.el.clone()).read().await?;
         (self.decode)(words).map_err(|e| Error::Conversion(format!("{e:?}")))
     }
 
     async fn insert(
         &self,
-        kw: Keyword,
-        vs: impl Sync + Send + IntoIterator<Item = Value>,
+        keyword: Keyword,
+        values: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> Result<(), Self::Error> {
-        self.push(Op::Insert, kw, vs.into_iter().collect()).await
+        self.push(Op::Insert, keyword, values.into_iter().collect())
+            .await
     }
 
     async fn delete(
         &self,
-        kw: Keyword,
-        vs: impl Sync + Send + IntoIterator<Item = Value>,
+        keyword: Keyword,
+        values: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> Result<(), Self::Error> {
-        self.push(Op::Delete, kw, vs.into_iter().collect()).await
+        self.push(Op::Delete, keyword, values.into_iter().collect())
+            .await
     }
 }
 
@@ -133,7 +135,7 @@ mod tests {
 
     #[test]
     fn test_insert_search_delete_search() {
-        let mut rng = ChaChaRng::from_entropy();
+        let mut rng = ChaChaRng::from_os_rng();
         let seed = Secret::random(&mut rng);
         let memory = MemoryEncryptionLayer::new(
             &seed,

--- a/src/findex.rs
+++ b/src/findex.rs
@@ -8,8 +8,11 @@ use std::{
 };
 
 use crate::{
-    ADDRESS_LENGTH, Address, Decoder, Encoder, IndexADT, KEY_LENGTH, MemoryADT, Secret,
-    adt::VectorADT, error::Error, memory::MemoryEncryptionLayer, ovec::IVec,
+    ADDRESS_LENGTH, Address, IndexADT, MemoryADT,
+    adt::VectorADT,
+    encoding::{Decoder, Encoder},
+    error::Error,
+    ovec::IVec,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -25,7 +28,7 @@ pub struct Findex<
     EncodingError: Send + Sync + Debug,
     Memory: Send + Sync + Clone + MemoryADT<Address = Address<ADDRESS_LENGTH>, Word = [u8; WORD_LENGTH]>,
 > {
-    el: MemoryEncryptionLayer<WORD_LENGTH, Memory>,
+    el: Memory,
     encode: Arc<Encoder<Value, Memory::Word, EncodingError>>,
     decode: Arc<Decoder<Value, Memory::Word, EncodingError>>,
 }
@@ -39,13 +42,12 @@ impl<
 {
     /// Instantiates Findex with the given seed, and memory.
     pub fn new(
-        seed: &Secret<KEY_LENGTH>,
-        mem: Memory,
-        encode: fn(Op, HashSet<Value>) -> Result<Vec<[u8; WORD_LENGTH]>, EncodingError>,
-        decode: fn(Vec<[u8; WORD_LENGTH]>) -> Result<HashSet<Value>, EncodingError>,
+        memory: Memory,
+        encode: Encoder<Value, Memory::Word, EncodingError>,
+        decode: Decoder<Value, Memory::Word, EncodingError>,
     ) -> Self {
         Self {
-            el: MemoryEncryptionLayer::new(seed, mem),
+            el: memory,
             encode: Arc::new(encode),
             decode: Arc::new(decode),
         }
@@ -124,7 +126,7 @@ mod tests {
 
     use crate::{
         ADDRESS_LENGTH, Findex, InMemory, IndexADT, Value, address::Address, dummy_decode,
-        dummy_encode, secret::Secret,
+        dummy_encode, memory::MemoryEncryptionLayer, secret::Secret,
     };
 
     const WORD_LENGTH: usize = 16;
@@ -133,8 +135,11 @@ mod tests {
     fn test_insert_search_delete_search() {
         let mut rng = ChaChaRng::from_entropy();
         let seed = Secret::random(&mut rng);
-        let memory = InMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::default();
-        let findex = Findex::new(&seed, memory, dummy_encode::<WORD_LENGTH, _>, dummy_decode);
+        let memory = MemoryEncryptionLayer::new(
+            &seed,
+            InMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::default(),
+        );
+        let findex = Findex::new(memory, dummy_encode::<WORD_LENGTH, _>, dummy_decode);
         let cat_bindings = [Value::from(1), Value::from(3), Value::from(5)];
         let dog_bindings = [Value::from(0), Value::from(2), Value::from(4)];
         block_on(findex.insert("cat".to_string(), cat_bindings.clone())).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub use encoding::{
 pub use error::Error;
 pub use findex::Findex;
 pub use findex::Op;
+pub use memory::MemoryEncryptionLayer;
 pub use secret::Secret;
 pub use value::Value;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::all, clippy::nursery, clippy::cargo)]
+#![allow(clippy::multiple_crate_versions)]
 
 mod address;
 mod adt;
@@ -9,12 +10,11 @@ mod memory;
 mod ovec;
 mod secret;
 mod symmetric_key;
-
-#[cfg(any(test, feature = "test-utils"))]
-pub use adt::test_utils;
 mod value;
 
 pub use address::Address;
+#[cfg(any(test, feature = "test-utils"))]
+pub use adt::test_utils;
 pub use adt::{IndexADT, MemoryADT};
 pub use encoding::{
     Decoder, Encoder,
@@ -28,7 +28,7 @@ pub use secret::Secret;
 pub use value::Value;
 
 #[cfg(feature = "redis-mem")]
-pub use memory::redis_store::{MemoryError, RedisMemory};
+pub use memory::{MemoryError, RedisMemory};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use encoding::{

--- a/src/memory/in_memory_store.rs
+++ b/src/memory/in_memory_store.rs
@@ -52,9 +52,9 @@ impl<Address: Send + Sync + Hash + Eq + Debug, Value: Send + Sync + Clone + Eq +
 
     type Error = MemoryError;
 
-    async fn batch_read(&self, a: Vec<Address>) -> Result<Vec<Option<Value>>, Self::Error> {
+    async fn batch_read(&self, addresses: Vec<Address>) -> Result<Vec<Option<Value>>, Self::Error> {
         let store = self.inner.lock().expect("poisoned lock");
-        Ok(a.iter().map(|k| store.get(k).cloned()).collect())
+        Ok(addresses.iter().map(|k| store.get(k).cloned()).collect())
     }
 
     async fn guarded_write(

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,12 +1,12 @@
 mod encryption_layer;
+pub use encryption_layer::MemoryEncryptionLayer;
 
 #[cfg(any(test, feature = "test-utils"))]
 mod in_memory_store;
-
-pub use encryption_layer::MemoryEncryptionLayer;
-
-#[cfg(feature = "redis-mem")]
-pub mod redis_store;
-
 #[cfg(any(test, feature = "test-utils"))]
 pub use in_memory_store::InMemory;
+
+#[cfg(feature = "redis-mem")]
+mod redis_store;
+#[cfg(feature = "redis-mem")]
+pub use redis_store::{MemoryError, RedisMemory};

--- a/src/memory/redis_store.rs
+++ b/src/memory/redis_store.rs
@@ -137,8 +137,11 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
 mod tests {
 
     use super::*;
-    use crate::adt::test_utils::{
-        test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard,
+    use crate::{
+        WORD_LENGTH,
+        adt::test_utils::{
+            test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard,
+        },
     };
 
     fn get_redis_url() -> String {
@@ -151,21 +154,21 @@ mod tests {
     #[tokio::test]
     async fn test_rw_seq() -> Result<(), MemoryError> {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_single_write_and_read(&m, rand::random()).await;
+        test_single_write_and_read::<WORD_LENGTH, _>(&m, rand::random()).await;
         Ok(())
     }
 
     #[tokio::test]
     async fn test_guard_seq() -> Result<(), MemoryError> {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_wrong_guard(&m, rand::random()).await;
+        test_wrong_guard::<WORD_LENGTH, _>(&m, rand::random()).await;
         Ok(())
     }
 
     #[tokio::test]
     async fn test_rw_ccr() -> Result<(), MemoryError> {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_guarded_write_concurrent(&m, rand::random()).await;
+        test_guarded_write_concurrent::<WORD_LENGTH, _>(&m, rand::random()).await;
         Ok(())
     }
 }

--- a/src/ovec.rs
+++ b/src/ovec.rs
@@ -111,7 +111,7 @@ where
 
     type Error = Error<Memory::Address>;
 
-    async fn push(&mut self, vs: Vec<Self::Value>) -> Result<(), Self::Error> {
+    async fn push(&mut self, values: Vec<Self::Value>) -> Result<(), Self::Error> {
         // Findex modifications are only lock-free, hence it does not guarantee a given client will
         // ever terminate.
         //
@@ -122,11 +122,11 @@ where
         loop {
             // Generates a new header with incremented counter.
             let mut new = old.clone().unwrap_or_default();
-            new.cnt += vs.len() as u64;
+            new.cnt += values.len() as u64;
 
             // Binds the correct addresses to the values.
-            let mut bindings = (new.cnt - vs.len() as u64..new.cnt)
-                .zip(vs.clone())
+            let mut bindings = (new.cnt - values.len() as u64..new.cnt)
+                .zip(values.clone())
                 .map(|(i, v)| (self.a.clone() + 1 + i, v)) // a is the header address
                 .collect::<Vec<_>>();
             bindings.push((
@@ -177,7 +177,9 @@ where
             .map_err(|e| Error::Memory(e.to_string()))?;
 
         let second_batch = {
-            let cur_header = first_batch[0]
+            let cur_header = first_batch
+                .first()
+                .ok_or_else(|| Error::MissingValue(self.a.clone(), 0))?
                 .map(|v| Header::try_from(v.as_slice()))
                 .transpose()
                 .map_err(Error::Conversion)?
@@ -225,7 +227,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_ovec() {
-        let mut rng = ChaChaRng::from_entropy();
+        let mut rng = ChaChaRng::from_os_rng();
         let seed = Secret::random(&mut rng);
         let memory = InMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::default();
         let obf = MemoryEncryptionLayer::new(&seed, memory.clone());

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -5,7 +5,7 @@ use std::{
 
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// Holds a secret information of `LENGTH` bytes.
 ///
@@ -23,7 +23,7 @@ impl<const LENGTH: usize> Secret<LENGTH> {
     }
 
     /// Creates a new random secret using the given RNG.
-    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
+    pub fn random(rng: &mut impl CryptoRng) -> Self {
         let mut secret = Self::new();
         rng.fill_bytes(&mut secret);
         secret


### PR DESCRIPTION
In order to allow switching the default encryption layer with an ad-hoc one -- for example calling a KMS instead of performing cryptographic operations locally -- the encryption layer needs to be specified. Rather than adding yet another generic for this layer _and_ for its key, an encrypted memory is given to Findex rather than a plaintext one.