### PR TITLE
Small improvements.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ name = "cosmian_findex"
 path = "src/lib.rs"
 
 [features]
-bench = []
 redis-mem = ["redis"]
 test-utils = []
 
@@ -53,8 +52,8 @@ tokio = { version = "1.38.0", features = [
 [[bench]]
 name = "benches"
 harness = false
-required-features = ["bench"]
+required-features = ["test-utils"]
 
 [[example]]
 name = "insert"
-required-features = ["bench"]
+required-features = ["test-utils"]

--- a/src/adt/mod.rs
+++ b/src/adt/mod.rs
@@ -1,7 +1,9 @@
 mod interfaces;
+
+pub use interfaces::{IndexADT, MemoryADT, VectorADT};
+
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;
 
 #[cfg(test)]
 pub use interfaces::tests;
-pub use interfaces::{IndexADT, MemoryADT, VectorADT};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,10 @@ pub use value::Value;
 #[cfg(feature = "redis-mem")]
 pub use memory::redis_store::{MemoryError, RedisMemory};
 
-#[cfg(any(feature = "redis-mem", feature = "bench"))]
+#[cfg(feature = "test-utils")]
 pub use encoding::{WORD_LENGTH, dummy_decode, dummy_encode};
-#[cfg(any(test, feature = "bench"))]
+
+#[cfg(any(test, feature = "test-utils"))]
 pub use memory::InMemory;
 
 /// 16-byte addresses ensure a high collision resistance that poses virtually no limitation on the

--- a/src/memory/in_memory_store.rs
+++ b/src/memory/in_memory_store.rs
@@ -32,14 +32,12 @@ impl<Address: Hash + Eq + Debug, Value: Clone + Eq + Debug> Default for InMemory
 }
 
 impl<Address: Hash + Eq + Debug, Value: Clone + Eq + Debug> InMemory<Address, Value> {
-    #[cfg(feature = "bench")]
     pub fn with_capacity(c: usize) -> Self {
         Self {
             inner: Arc::new(Mutex::new(HashMap::with_capacity(c))),
         }
     }
 
-    #[cfg(any(test, feature = "bench"))]
     pub fn clear(&self) {
         self.inner.lock().expect("poisoned lock").clear();
     }
@@ -76,7 +74,6 @@ impl<Address: Send + Sync + Hash + Eq + Debug, Value: Send + Sync + Clone + Eq +
     }
 }
 
-#[cfg(feature = "bench")]
 impl<Address: Hash + Eq + Debug + Clone, Value: Clone + Eq + Debug> IntoIterator
     for InMemory<Address, Value>
 {
@@ -92,6 +89,7 @@ impl<Address: Hash + Eq + Debug + Clone, Value: Clone + Eq + Debug> IntoIterator
             .into_iter()
     }
 }
+
 #[cfg(test)]
 mod tests {
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,4 +1,6 @@
 mod encryption_layer;
+
+#[cfg(any(test, feature = "test-utils"))]
 mod in_memory_store;
 
 pub use encryption_layer::MemoryEncryptionLayer;
@@ -6,5 +8,5 @@ pub use encryption_layer::MemoryEncryptionLayer;
 #[cfg(feature = "redis-mem")]
 pub mod redis_store;
 
-#[cfg(any(test, feature = "bench"))]
+#[cfg(any(test, feature = "test-utils"))]
 pub use in_memory_store::InMemory;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,8 +1,10 @@
 mod encryption_layer;
 mod in_memory_store;
+
+pub use encryption_layer::MemoryEncryptionLayer;
+
 #[cfg(feature = "redis-mem")]
 pub mod redis_store;
 
-pub use encryption_layer::MemoryEncryptionLayer;
 #[cfg(any(test, feature = "bench"))]
 pub use in_memory_store::InMemory;

--- a/src/memory/redis_store.rs
+++ b/src/memory/redis_store.rs
@@ -17,7 +17,7 @@ local length = ARGV[3]
 local value = redis.call('GET',ARGV[1])
 
 -- compare the value of the guard to the currently stored value
-if((value==false) or (not(value == false) and (guard_value == value))) then
+if ((value == false) or (guard_value == value)) then
     -- guard passed, loop over bindings and insert them
     for i = 4,(length*2)+3,2
     do
@@ -48,7 +48,7 @@ impl From<RedisError> for MemoryError {
 
 #[derive(Clone)]
 pub struct RedisMemory<Address, Word> {
-    pub manager: ConnectionManager,
+    manager: ConnectionManager,
     script_hash: String,
     a: PhantomData<Address>,
     w: PhantomData<Word>,
@@ -65,13 +65,15 @@ impl<Address, Word> fmt::Debug for RedisMemory<Address, Word> {
 impl<Address: Sync, Word: Sync> RedisMemory<Address, Word> {
     /// Connects to a Redis server with a `ConnectionManager`.
     pub async fn connect_with_manager(mut manager: ConnectionManager) -> Result<Self, MemoryError> {
+        let script_hash = redis::cmd("SCRIPT")
+            .arg("LOAD")
+            .arg(GUARDED_WRITE_LUA_SCRIPT)
+            .query_async(&mut manager)
+            .await?;
+
         Ok(Self {
-            manager: manager.clone(),
-            script_hash: redis::cmd("SCRIPT")
-                .arg("LOAD")
-                .arg(GUARDED_WRITE_LUA_SCRIPT)
-                .query_async(&mut manager)
-                .await?,
+            manager,
+            script_hash,
             a: PhantomData,
             w: PhantomData,
         })
@@ -89,8 +91,8 @@ impl<const WORD_LENGTH: usize> MemoryADT
     for RedisMemory<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>
 {
     type Address = Address<ADDRESS_LENGTH>;
-    type Error = MemoryError;
     type Word = [u8; WORD_LENGTH];
+    type Error = MemoryError;
 
     async fn batch_read(
         &self,
@@ -98,6 +100,7 @@ impl<const WORD_LENGTH: usize> MemoryADT
     ) -> Result<Vec<Option<Self::Word>>, Self::Error> {
         let mut cmd = redis::cmd("MGET");
         let cmd = addresses.iter().fold(&mut cmd, |c, a| c.arg(&**a));
+        // Cloning the connection manager is cheap since it is an `Arc`.
         cmd.query_async(&mut self.manager.clone())
             .await
             .map_err(Self::Error::from)
@@ -113,18 +116,19 @@ impl<const WORD_LENGTH: usize> MemoryADT
         let cmd = cmd
             .arg(self.script_hash.as_str())
             .arg(0)
-            .arg(&*guard_address);
-
-        let cmd = if let Some(byte_array) = guard_value {
-            cmd.arg(&byte_array)
-        } else {
-            cmd.arg("false")
-        };
+            .arg(&*guard_address)
+            .arg(
+                guard_value
+                    .as_ref()
+                    .map(|bytes| bytes.as_slice())
+                    .unwrap_or(b"false".as_slice()),
+            );
 
         let cmd = bindings
             .iter()
             .fold(cmd.arg(bindings.len()), |cmd, (a, w)| cmd.arg(&**a).arg(w));
 
+        // Cloning the connection manager is cheap since it is an `Arc`.
         cmd.query_async(&mut self.manager.clone())
             .await
             .map_err(Self::Error::from)
@@ -146,31 +150,23 @@ mod tests {
         )
     }
 
-    const WORD_LENGTH: usize = 16;
-
     #[tokio::test]
     async fn test_rw_seq() -> Result<(), MemoryError> {
-        let m = RedisMemory::<_, [u8; WORD_LENGTH]>::connect(&get_redis_url())
-            .await
-            .unwrap();
+        let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
         test_single_write_and_read(&m, rand::random()).await;
         Ok(())
     }
 
     #[tokio::test]
     async fn test_guard_seq() -> Result<(), MemoryError> {
-        let m = RedisMemory::<_, [u8; WORD_LENGTH]>::connect(&get_redis_url())
-            .await
-            .unwrap();
+        let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
         test_wrong_guard(&m, rand::random()).await;
         Ok(())
     }
 
     #[tokio::test]
     async fn test_rw_ccr() -> Result<(), MemoryError> {
-        let m = RedisMemory::<_, [u8; WORD_LENGTH]>::connect(&get_redis_url())
-            .await
-            .unwrap();
+        let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
         test_guarded_write_concurrent(&m, rand::random()).await;
         Ok(())
     }


### PR DESCRIPTION
Notable changes:
- remove a clone when instantiating a Redis memory;
- strengthen the concurrency test by looping `N` times in each concurrent worker
- remove a redundant condition in the g-write script
- remove some unnecessary bounds in the generic tests
- remove redundant documentation (please, refrain your LLM)
- remove the `bench` feature