### PR TITLE
fix: keep lost error logs

### DIFF
--- a/src/memory/redis_store.rs
+++ b/src/memory/redis_store.rs
@@ -34,7 +34,7 @@ pub struct MemoryError {
 
 impl fmt::Display for MemoryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Memory Error")
+        write!(f, "Redis store memory error: {}", self.inner)
     }
 }
 


### PR DESCRIPTION
Very quick fix for redis error getting lost rendering debug of encoding problems almost impossible to be done
Here is an example from the related server

What used to happen in case of encoding problem : 
`Error: FindexError(Conversion("\"insufficient bytes in a word to fit a value of length 163\""))`

What is supposed to happen (thanks to this little 1 line update ) : 
`Error: FindexError(Memory("asba1: REST Request Failed: /indexes/f4052ec7-e374-4e9b-8479-f98d883ae2ac/guarded_write: Database Error: : Memory Error: Response was of incompatible type - TypeError: \"Response has wrong dimension, expected 130, got 129\" (response was binary-data([250, 209, 216, 117, 233, 65, 220, 172, 52, 160, 255, 113, 235, 28, 54, 220, 225, 1, 201, 44, 55, 80, 129, 198, 128, 112, 113, 226, 157, 124, 215, 233, 210, 91, 198, 39, 34, 93, 12, 172, 99, 255, 241, 105, 196, 201, 131, 38, 42, 203, 236, 88, 31, 32, 198, 172, 98, 179, 61, 115, 234, 105, 211, 172, 73, 144, 67, 13, 233, 240, 178, 158, 183, 243, 224, 94, 139, 108, 241, 154, 187, 3, 186, 89, 227, 40, 77, 156, 200, 206, 212, 128, 238, 7, 114, 74, 74, 224, 163, 68, 81, 188, 248, 173, 186, 76, 12, 83, 159, 163, 114, 159, 170, 76, 107, 171, 145, 0, 89, 23, 69, 104, 150, 43, 192, 0, 109, 117, 250]))"))`