### PR TITLE
fix: convert indexing slicing to error VectorADT::read()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ name: CI checks
 on: push
 
 jobs:
+  hack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
   cargo-lint:
     uses: Cosmian/reusable_workflows/.github/workflows/cargo-nursery.yml@develop
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,6 @@ name: CI checks
 on: push
 
 jobs:
-  hack:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2
   cargo-lint:
     uses: Cosmian/reusable_workflows/.github/workflows/cargo-nursery.yml@develop
     with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-exclude: datasets|tests_data|documentation/Findex.pdf|tests/first_names.txt
+exclude: benches/data|benches/make_figures.tex
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v2.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,20 +118,21 @@ repos:
         args: [--skip-string-normalization]
 
   - repo: https://github.com/Cosmian/git-hooks.git
-    rev: v1.0.16
+    rev: v1.0.36
     hooks:
       - id: stable-cargo-format
-      - id: cargo-upgrade
-      - id: cargo-update
+      # - id: dprint-toml-fix
+      # - id: cargo-upgrade
+      # - id: cargo-update
       - id: cargo-machete
-      - id: cargo-outdated
-      - id: cargo-udeps
+      - id: redis-container-up
       - id: cargo-tests-all
       - id: cargo-test-doc
-      - id: clippy-autofix-all
-      - id: clippy-autofix-pedantic
-      - id: clippy-autofix-others
+      - id: clippy-autofix-all-targets-all-features
+      - id: clippy-autofix-all-targets
       - id: clippy-all-targets-all-features
+      - id: clippy-all-targets
       - id: stable-cargo-format
       - id: cargo-dry-publish
         args: [--allow-dirty]
+      - id: redis-container-down

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ test-utils = []
 
 [dependencies]
 aes = "0.8.4"
-rand = "0.8.5"
-rand_chacha = "0.3.1"
-rand_core = "0.6.4"
-redis = { version = "0.28.1", features = [
+rand = "0.9.0"
+rand_chacha = "0.9.0"
+rand_core = "0.9.0"
+redis = { version = "0.28.2", features = [
     "aio",
     "connection-manager",
     "tokio-comp",
@@ -40,9 +40,9 @@ zeroize = { version = "1.8.1", features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.5.1"
-futures = "0.3.30"
+futures = "0.3.31"
 lazy_static = "1.5.0"
-tokio = { version = "1.38.0", features = [
+tokio = { version = "1.43.0", features = [
     "macros",
     "rt",
     "rt-multi-thread",

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,7 +4,7 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             Cosmian Tech SAS.
-Licensed Work:        Cosmian KMS version 4.11.3 or later.
+Licensed Work:        Cosmian Findex version 6.0.0 or later.
                       The Licensed Work is (c) 2024 Cosmian Tech SAS.
 Additional Use Grant: You may use the Licensed Work in production, provided
                       your total use of does not exceed a total of 4 vCPUS on virtual

--- a/examples/insert.rs
+++ b/examples/insert.rs
@@ -3,7 +3,7 @@
 use cosmian_findex::{Findex, InMemory, IndexADT, MemoryEncryptionLayer, Op, Secret};
 use futures::executor::block_on;
 use rand_chacha::ChaChaRng;
-use rand_core::{CryptoRngCore, SeedableRng};
+use rand_core::{CryptoRng, SeedableRng};
 use std::collections::{HashMap, HashSet};
 
 /// This function generates a random set of (key, values) couples. Since Findex
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 /// associated *keyword* of type `[u8; 8]` in this example. Since Findex only
 /// requires from the values to be hashable, we could have taken any type that
 /// implements `Hash` instead of the `u64`.
-fn gen_index(rng: &mut impl CryptoRngCore) -> HashMap<[u8; 8], HashSet<u64>> {
+fn gen_index(rng: &mut impl CryptoRng) -> HashMap<[u8; 8], HashSet<u64>> {
     (0..6)
         .map(|i| {
             let kw = rng.next_u64().to_be_bytes();
@@ -86,7 +86,7 @@ fn decoder(words: Vec<[u8; WORD_LENGTH]>) -> Result<HashSet<u64>, String> {
 fn main() {
     // For cryptographic applications, it is important to use a secure RNG. In
     // Rust, those RNG implement the `CryptoRng` trait.
-    let mut rng = ChaChaRng::from_entropy();
+    let mut rng = ChaChaRng::from_os_rng();
 
     // Generate fresh Findex key. In practice only one user is in charge of
     // generating the key (the administrator?): all users *must* share the same

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Deref, DerefMut};
 
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 // NOTE: a more efficient implementation of the address could be a big-int.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -39,7 +39,7 @@ impl<const LENGTH: usize> Default for Address<LENGTH> {
 }
 
 impl<const LENGTH: usize> Address<LENGTH> {
-    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
+    pub fn random(rng: &mut impl CryptoRng) -> Self {
         let mut res = Self([0; LENGTH]);
         rng.fill_bytes(&mut *res);
         res

--- a/src/adt/interfaces.rs
+++ b/src/adt/interfaces.rs
@@ -64,7 +64,7 @@ pub trait MemoryADT {
     /// Reads the words from the given addresses.
     fn batch_read(
         &self,
-        a: Vec<Self::Address>,
+        addresses: Vec<Self::Address>,
     ) -> impl Send + Future<Output = Result<Vec<Option<Self::Word>>, Self::Error>>;
 
     /// Write the given words at the given addresses if the word currently stored at the guard

--- a/src/adt/interfaces.rs
+++ b/src/adt/interfaces.rs
@@ -7,7 +7,7 @@
 
 use std::{collections::HashSet, future::Future, hash::Hash};
 
-/// An index stores *bindings*, that associate a keyword with a value. All values bound to the same
+/// An index stores *values*, that associate a keyword with a value. All values bound to the same
 /// keyword are said to be *indexed under* this keyword.
 pub trait IndexADT<Keyword: Send + Sync + Hash, Value: Send + Sync + Hash> {
     type Error: Send + Sync + std::error::Error;
@@ -18,18 +18,18 @@ pub trait IndexADT<Keyword: Send + Sync + Hash, Value: Send + Sync + Hash> {
         keyword: &Keyword,
     ) -> impl Future<Output = Result<HashSet<Value>, Self::Error>>;
 
-    /// Adds the given bindings to the index.
+    /// Adds the given values to the index.
     fn insert(
         &self,
         keyword: Keyword,
-        bindings: impl Sync + Send + IntoIterator<Item = Value>,
+        values: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> impl Send + Future<Output = Result<(), Self::Error>>;
 
-    /// Removes the given bindings from the index.
+    /// Removes the given values from the index.
     fn delete(
         &self,
         keyword: Keyword,
-        bindings: impl Sync + Send + IntoIterator<Item = Value>,
+        values: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> impl Send + Future<Output = Result<(), Self::Error>>;
 }
 
@@ -43,7 +43,7 @@ pub trait VectorADT: Send + Sync {
     /// Pushes the given values at the end of this vector.
     fn push(
         &mut self,
-        vs: Vec<Self::Value>,
+        values: Vec<Self::Value>,
     ) -> impl Send + Future<Output = Result<(), Self::Error>>;
 
     /// Reads all values stored in this vector.
@@ -72,7 +72,7 @@ pub trait MemoryADT {
     fn guarded_write(
         &self,
         guard: (Self::Address, Option<Self::Word>),
-        tasks: Vec<(Self::Address, Self::Word)>,
+        bindings: Vec<(Self::Address, Self::Word)>,
     ) -> impl Send + Future<Output = Result<Option<Self::Word>, Self::Error>>;
 }
 

--- a/src/adt/interfaces.rs
+++ b/src/adt/interfaces.rs
@@ -21,14 +21,14 @@ pub trait IndexADT<Keyword: Send + Sync + Hash, Value: Send + Sync + Hash> {
     /// Adds the given bindings to the index.
     fn insert(
         &self,
-        kw: Keyword,
+        keyword: Keyword,
         bindings: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> impl Send + Future<Output = Result<(), Self::Error>>;
 
     /// Removes the given bindings from the index.
     fn delete(
         &self,
-        kw: Keyword,
+        keyword: Keyword,
         bindings: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> impl Send + Future<Output = Result<(), Self::Error>>;
 }

--- a/src/adt/test_utils.rs
+++ b/src/adt/test_utils.rs
@@ -87,7 +87,7 @@ where
     let conflict_result = memory
         .guarded_write((a.clone(), None), vec![(
             a.clone(),
-            Memory::Word::from(rng.gen::<u128>().to_be_bytes()),
+            Memory::Word::from(rng.random::<u128>().to_be_bytes()),
         )])
         .await
         .unwrap();

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -237,13 +237,13 @@ pub mod generic_encoding {
 
     #[cfg(test)]
     mod tests {
-        use rand::{RngCore, thread_rng};
+        use rand::{RngCore, rng};
 
         use super::*;
 
         #[test]
         fn test_metadata_encoding() {
-            let mut rng = thread_rng();
+            let mut rng = rng();
             for _ in 0..1000 {
                 let op = if rng.next_u32() % 2 == 1 {
                     Op::Insert
@@ -266,7 +266,7 @@ pub mod generic_encoding {
 pub mod tests {
     use crate::Op;
 
-    use rand::{RngCore, thread_rng};
+    use rand::{RngCore, rng};
     use std::{collections::HashSet, fmt::Debug, hash::Hash};
 
     use super::{Decoder, Encoder};
@@ -300,7 +300,7 @@ pub mod tests {
         encode: Encoder<Value, Word, EncodingError>,
         decode: Decoder<Value, Word, EncodingError>,
     ) {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         // Draws a random number of operations in [0,100].
         let n_ops = rng.next_u32() % 10;

--- a/src/findex.rs
+++ b/src/findex.rs
@@ -74,11 +74,11 @@ impl<
     async fn push<Keyword: Send + Sync + Hash + Eq>(
         &self,
         op: Op,
-        kw: Keyword,
-        vs: HashSet<Value>,
+        keyword: Keyword,
+        values: HashSet<Value>,
     ) -> Result<(), <Self as IndexADT<Keyword, Value>>::Error> {
-        let words = (self.encode)(op, vs).map_err(|e| Error::Conversion(format!("{e:?}")))?;
-        let l = Self::hash_keyword(&kw);
+        let words = (self.encode)(op, values).map_err(|e| Error::Conversion(format!("{e:?}")))?;
+        let l = Self::hash_keyword(&keyword);
         IVec::new(l, self.el.clone()).push(words).await
     }
 }
@@ -93,26 +93,28 @@ impl<
 {
     type Error = Error<Address<ADDRESS_LENGTH>>;
 
-    async fn search(&self, kw: &Keyword) -> Result<HashSet<Value>, Self::Error> {
-        let l = Self::hash_keyword(kw);
+    async fn search(&self, keyword: &Keyword) -> Result<HashSet<Value>, Self::Error> {
+        let l = Self::hash_keyword(keyword);
         let words = IVec::new(l, self.el.clone()).read().await?;
         (self.decode)(words).map_err(|e| Error::Conversion(format!("{e:?}")))
     }
 
     async fn insert(
         &self,
-        kw: Keyword,
-        vs: impl Sync + Send + IntoIterator<Item = Value>,
+        keyword: Keyword,
+        bindings: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> Result<(), Self::Error> {
-        self.push(Op::Insert, kw, vs.into_iter().collect()).await
+        self.push(Op::Insert, keyword, bindings.into_iter().collect())
+            .await
     }
 
     async fn delete(
         &self,
-        kw: Keyword,
-        vs: impl Sync + Send + IntoIterator<Item = Value>,
+        keyword: Keyword,
+        bindings: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> Result<(), Self::Error> {
-        self.push(Op::Delete, kw, vs.into_iter().collect()).await
+        self.push(Op::Delete, keyword, bindings.into_iter().collect())
+            .await
     }
 }
 

--- a/src/findex.rs
+++ b/src/findex.rs
@@ -133,7 +133,7 @@ mod tests {
 
     #[test]
     fn test_insert_search_delete_search() {
-        let mut rng = ChaChaRng::from_entropy();
+        let mut rng = ChaChaRng::from_os_rng();
         let seed = Secret::random(&mut rng);
         let memory = MemoryEncryptionLayer::new(
             &seed,

--- a/src/findex.rs
+++ b/src/findex.rs
@@ -102,18 +102,18 @@ impl<
     async fn insert(
         &self,
         keyword: Keyword,
-        bindings: impl Sync + Send + IntoIterator<Item = Value>,
+        values: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> Result<(), Self::Error> {
-        self.push(Op::Insert, keyword, bindings.into_iter().collect())
+        self.push(Op::Insert, keyword, values.into_iter().collect())
             .await
     }
 
     async fn delete(
         &self,
         keyword: Keyword,
-        bindings: impl Sync + Send + IntoIterator<Item = Value>,
+        values: impl Sync + Send + IntoIterator<Item = Value>,
     ) -> Result<(), Self::Error> {
-        self.push(Op::Delete, keyword, bindings.into_iter().collect())
+        self.push(Op::Delete, keyword, values.into_iter().collect())
             .await
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,4 @@
 #![warn(clippy::all, clippy::nursery, clippy::cargo)]
-// Why allowing #![allow(clippy::multiple_crate_versions)]
-// Error details: multiple versions for dependency `zerocopy`:
-// - 0.7.35: ppv-lite86
-// - 0.8.16: rand
-// As soon ppv-lite86 will have upgraded `zerocopy` to 0.8.16, the lint will be fixed.
-// For now, let's tolerate this warning.
 #![allow(clippy::multiple_crate_versions)]
 
 mod address;
@@ -51,4 +45,4 @@ pub const ADDRESS_LENGTH: usize = 16;
 
 /// Using 32-byte cryptographic keys allows achieving post-quantum resistance
 /// with the AES primitive.
-pub const SEED_LENGTH: usize = 32;
+pub const KEY_LENGTH: usize = 32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,11 @@
 #![warn(clippy::all, clippy::nursery, clippy::cargo)]
+// Why allowing #![allow(clippy::multiple_crate_versions)]
+// Error details: multiple versions for dependency `zerocopy`:
+// - 0.7.35: ppv-lite86
+// - 0.8.16: rand
+// As soon ppv-lite86 will have upgraded `zerocopy` to 0.8.16, the lint will be fixed.
+// For now, let's tolerate this warning.
+#![allow(clippy::multiple_crate_versions)]
 
 mod address;
 mod adt;
@@ -9,13 +16,16 @@ mod memory;
 mod ovec;
 mod secret;
 mod symmetric_key;
-
-#[cfg(any(test, feature = "test-utils"))]
-pub use adt::test_utils;
 mod value;
 
 pub use address::Address;
+#[cfg(any(test, feature = "test-utils"))]
+pub use adt::test_utils;
 pub use adt::{IndexADT, MemoryADT};
+pub use encoding::{
+    Decoder, Encoder,
+    generic_encoding::{generic_decode, generic_encode},
+};
 pub use error::Error;
 pub use findex::Findex;
 pub use findex::Op;
@@ -41,4 +51,4 @@ pub const ADDRESS_LENGTH: usize = 16;
 
 /// Using 32-byte cryptographic keys allows achieving post-quantum resistance
 /// with the AES primitive.
-pub const KEY_LENGTH: usize = 32;
+pub const SEED_LENGTH: usize = 32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,6 @@ mod value;
 
 pub use address::Address;
 pub use adt::{IndexADT, MemoryADT};
-pub use encoding::{
-    Decoder, Encoder,
-    generic_encoding::{generic_decode, generic_encode},
-};
 pub use error::Error;
 pub use findex::Findex;
 pub use findex::Op;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use secret::Secret;
 pub use value::Value;
 
 #[cfg(feature = "redis-mem")]
-pub use memory::redis_store::{MemoryError, RedisMemory};
+pub use memory::{MemoryError, RedisMemory};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use encoding::{

--- a/src/memory/encryption_layer.rs
+++ b/src/memory/encryption_layer.rs
@@ -253,19 +253,28 @@ mod tests {
 
     #[tokio::test]
     async fn test_sequential_read_write() {
-        let memory = create_memory(&mut ChaChaRng::from_os_rng());
-        test_single_write_and_read(&memory, rand::random()).await;
+        test_single_write_and_read::<WORD_LENGTH, _>(
+            &create_memory(&mut ChaChaRng::from_os_rng()),
+            rand::random(),
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_sequential_wrong_guard() {
-        let memory = InMemory::<[u8; 16], [u8; 16]>::default();
-        test_wrong_guard(&memory, rand::random()).await;
+        test_wrong_guard::<WORD_LENGTH, _>(
+            &create_memory(&mut ChaChaRng::from_os_rng()),
+            rand::random(),
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_concurrent_read_write() {
-        let memory = InMemory::<[u8; 16], [u8; 16]>::default();
-        test_guarded_write_concurrent(&memory, rand::random()).await;
+        test_guarded_write_concurrent::<WORD_LENGTH, _>(
+            &create_memory(&mut ChaChaRng::from_os_rng()),
+            rand::random(),
+        )
+        .await;
     }
 }

--- a/src/memory/encryption_layer.rs
+++ b/src/memory/encryption_layer.rs
@@ -108,12 +108,12 @@ impl<
     async fn guarded_write(
         &self,
         guard: (Self::Address, Option<Self::Word>),
-        tasks: Vec<(Self::Address, Self::Word)>,
+        bindings: Vec<(Self::Address, Self::Word)>,
     ) -> Result<Option<Self::Word>, Self::Error> {
         let (address, v) = guard;
         let tok = self.permute(address);
         let old = v.map(|v| self.encrypt(v, *tok));
-        let bindings = tasks
+        let bindings = bindings
             .into_iter()
             .map(|(a, v)| {
                 let tok = self.permute(a);

--- a/src/memory/encryption_layer.rs
+++ b/src/memory/encryption_layer.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, ops::Deref, sync::Arc};
 
 use crate::{
-    ADDRESS_LENGTH, MemoryADT, SEED_LENGTH, Secret, address::Address, symmetric_key::SymmetricKey,
+    ADDRESS_LENGTH, KEY_LENGTH, MemoryADT, Secret, address::Address, symmetric_key::SymmetricKey,
 };
 use aes::{
     Aes256,
@@ -46,12 +46,12 @@ impl<
 > MemoryEncryptionLayer<WORD_LENGTH, Memory>
 {
     /// Instantiates a new memory encryption layer.
-    pub fn new(seed: &Secret<SEED_LENGTH>, stm: Memory) -> Self {
-        let k_p = SymmetricKey::<SEED_LENGTH>::derive(seed, &[0]).expect("secret is large enough");
+    pub fn new(seed: &Secret<KEY_LENGTH>, stm: Memory) -> Self {
+        let k_p = SymmetricKey::<KEY_LENGTH>::derive(seed, &[0]).expect("secret is large enough");
         let k_e1 =
-            SymmetricKey::<{ SEED_LENGTH }>::derive(seed, &[1]).expect("secret is large enough");
+            SymmetricKey::<{ KEY_LENGTH }>::derive(seed, &[1]).expect("secret is large enough");
         let k_e2 =
-            SymmetricKey::<{ SEED_LENGTH }>::derive(seed, &[2]).expect("secret is large enough");
+            SymmetricKey::<{ KEY_LENGTH }>::derive(seed, &[2]).expect("secret is large enough");
         let aes = Aes256::new(GenericArray::from_slice(&k_p));
         let aes_e1 = Aes256::new(GenericArray::from_slice(&k_e1));
         let aes_e2 = Aes256::new(GenericArray::from_slice(&k_e2));

--- a/src/memory/in_memory_store.rs
+++ b/src/memory/in_memory_store.rs
@@ -60,13 +60,13 @@ impl<Address: Send + Sync + Hash + Eq + Debug, Value: Send + Sync + Clone + Eq +
     async fn guarded_write(
         &self,
         guard: (Self::Address, Option<Self::Word>),
-        tasks: Vec<(Self::Address, Self::Word)>,
+        bindings: Vec<(Self::Address, Self::Word)>,
     ) -> Result<Option<Self::Word>, Self::Error> {
         let store = &mut *self.inner.lock().expect("poisoned lock");
         let (a, old) = guard;
         let cur = store.get(&a).cloned();
         if old == cur {
-            for (k, v) in tasks {
+            for (k, v) in bindings {
                 store.insert(k, v);
             }
         }

--- a/src/memory/in_memory_store.rs
+++ b/src/memory/in_memory_store.rs
@@ -60,13 +60,13 @@ impl<Address: Send + Sync + Hash + Eq + Debug, Value: Send + Sync + Clone + Eq +
     async fn guarded_write(
         &self,
         guard: (Self::Address, Option<Self::Word>),
-        bindings: Vec<(Self::Address, Self::Word)>,
+        tasks: Vec<(Self::Address, Self::Word)>,
     ) -> Result<Option<Self::Word>, Self::Error> {
         let store = &mut *self.inner.lock().expect("poisoned lock");
         let (a, old) = guard;
         let cur = store.get(&a).cloned();
         if old == cur {
-            for (k, v) in bindings {
+            for (k, v) in tasks {
                 store.insert(k, v);
             }
         }

--- a/src/memory/in_memory_store.rs
+++ b/src/memory/in_memory_store.rs
@@ -52,9 +52,9 @@ impl<Address: Send + Sync + Hash + Eq + Debug, Value: Send + Sync + Clone + Eq +
 
     type Error = MemoryError;
 
-    async fn batch_read(&self, a: Vec<Address>) -> Result<Vec<Option<Value>>, Self::Error> {
+    async fn batch_read(&self, addresses: Vec<Address>) -> Result<Vec<Option<Value>>, Self::Error> {
         let store = self.inner.lock().expect("poisoned lock");
-        Ok(a.iter().map(|k| store.get(k).cloned()).collect())
+        Ok(addresses.iter().map(|k| store.get(k).cloned()).collect())
     }
 
     async fn guarded_write(

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,12 +1,12 @@
 mod encryption_layer;
+pub use encryption_layer::MemoryEncryptionLayer;
 
 #[cfg(any(test, feature = "test-utils"))]
 mod in_memory_store;
-
-pub use encryption_layer::MemoryEncryptionLayer;
-
-#[cfg(feature = "redis-mem")]
-pub mod redis_store;
-
 #[cfg(any(test, feature = "test-utils"))]
 pub use in_memory_store::InMemory;
+
+#[cfg(feature = "redis-mem")]
+mod redis_store;
+#[cfg(feature = "redis-mem")]
+pub use redis_store::{MemoryError, RedisMemory};

--- a/src/memory/redis_store.rs
+++ b/src/memory/redis_store.rs
@@ -137,8 +137,11 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
 mod tests {
 
     use super::*;
-    use crate::adt::test_utils::{
-        test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard,
+    use crate::{
+        WORD_LENGTH,
+        adt::test_utils::{
+            test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard,
+        },
     };
 
     fn get_redis_url() -> String {
@@ -151,21 +154,21 @@ mod tests {
     #[tokio::test]
     async fn test_rw_seq() -> Result<(), MemoryError> {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_single_write_and_read(&m, rand::random()).await;
+        test_single_write_and_read::<WORD_LENGTH, _>(&m, rand::random()).await;
         Ok(())
     }
 
     #[tokio::test]
     async fn test_guard_seq() -> Result<(), MemoryError> {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_wrong_guard(&m, rand::random()).await;
+        test_wrong_guard::<WORD_LENGTH, _>(&m, rand::random()).await;
         Ok(())
     }
 
     #[tokio::test]
     async fn test_rw_ccr() -> Result<(), MemoryError> {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_guarded_write_concurrent(&m, rand::random()).await;
+        test_guarded_write_concurrent::<WORD_LENGTH, _>(&m, rand::random()).await;
         Ok(())
     }
 }

--- a/src/memory/redis_store.rs
+++ b/src/memory/redis_store.rs
@@ -107,7 +107,7 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
     async fn guarded_write(
         &self,
         guard: (Self::Address, Option<Self::Word>),
-        bindings: Vec<(Self::Address, Self::Word)>,
+        tasks: Vec<(Self::Address, Self::Word)>,
     ) -> Result<Option<Self::Word>, Self::Error> {
         let (guard_address, guard_value) = guard;
         let mut cmd = redis::cmd("EVALSHA");
@@ -122,9 +122,9 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
                     .unwrap_or(b"false".as_slice()),
             );
 
-        let cmd = bindings
+        let cmd = tasks
             .iter()
-            .fold(cmd.arg(bindings.len()), |cmd, (a, w)| cmd.arg(&**a).arg(w));
+            .fold(cmd.arg(tasks.len()), |cmd, (a, w)| cmd.arg(&**a).arg(w));
 
         // Cloning the connection manager is cheap since it is an `Arc`.
         cmd.query_async(&mut self.manager.clone())

--- a/src/memory/redis_store.rs
+++ b/src/memory/redis_store.rs
@@ -107,7 +107,7 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
     async fn guarded_write(
         &self,
         guard: (Self::Address, Option<Self::Word>),
-        tasks: Vec<(Self::Address, Self::Word)>,
+        bindings: Vec<(Self::Address, Self::Word)>,
     ) -> Result<Option<Self::Word>, Self::Error> {
         let (guard_address, guard_value) = guard;
         let mut cmd = redis::cmd("EVALSHA");
@@ -122,9 +122,9 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
                     .unwrap_or(b"false".as_slice()),
             );
 
-        let cmd = tasks
+        let cmd = bindings
             .iter()
-            .fold(cmd.arg(tasks.len()), |cmd, (a, w)| cmd.arg(&**a).arg(w));
+            .fold(cmd.arg(bindings.len()), |cmd, (a, w)| cmd.arg(&**a).arg(w));
 
         // Cloning the connection manager is cheap since it is an `Arc`.
         cmd.query_async(&mut self.manager.clone())

--- a/src/ovec.rs
+++ b/src/ovec.rs
@@ -177,7 +177,9 @@ where
             .map_err(|e| Error::Memory(e.to_string()))?;
 
         let second_batch = {
-            let cur_header = first_batch[0]
+            let cur_header = first_batch
+                .first()
+                .ok_or_else(|| Error::MissingValue(self.a.clone(), 0))?
                 .map(|v| Header::try_from(v.as_slice()))
                 .transpose()
                 .map_err(Error::Conversion)?

--- a/src/ovec.rs
+++ b/src/ovec.rs
@@ -225,7 +225,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_ovec() {
-        let mut rng = ChaChaRng::from_entropy();
+        let mut rng = ChaChaRng::from_os_rng();
         let seed = Secret::random(&mut rng);
         let memory = InMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::default();
         let obf = MemoryEncryptionLayer::new(&seed, memory.clone());

--- a/src/ovec.rs
+++ b/src/ovec.rs
@@ -111,7 +111,7 @@ where
 
     type Error = Error<Memory::Address>;
 
-    async fn push(&mut self, vs: Vec<Self::Value>) -> Result<(), Self::Error> {
+    async fn push(&mut self, values: Vec<Self::Value>) -> Result<(), Self::Error> {
         // Findex modifications are only lock-free, hence it does not guarantee a given client will
         // ever terminate.
         //
@@ -122,11 +122,11 @@ where
         loop {
             // Generates a new header with incremented counter.
             let mut new = old.clone().unwrap_or_default();
-            new.cnt += vs.len() as u64;
+            new.cnt += values.len() as u64;
 
             // Binds the correct addresses to the values.
-            let mut bindings = (new.cnt - vs.len() as u64..new.cnt)
-                .zip(vs.clone())
+            let mut bindings = (new.cnt - values.len() as u64..new.cnt)
+                .zip(values.clone())
                 .map(|(i, v)| (self.a.clone() + 1 + i, v)) // a is the header address
                 .collect::<Vec<_>>();
             bindings.push((

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -5,7 +5,7 @@ use std::{
 
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// Holds a secret information of `LENGTH` bytes.
 ///
@@ -23,7 +23,7 @@ impl<const LENGTH: usize> Secret<LENGTH> {
     }
 
     /// Creates a new random secret using the given RNG.
-    pub fn random(rng: &mut impl CryptoRngCore) -> Self {
+    pub fn random(rng: &mut impl CryptoRng) -> Self {
         let mut secret = Self::new();
         rng.fill_bytes(&mut secret);
         secret


### PR DESCRIPTION
- fix: convert indexing slicing to error VectorADT::read()
- rename traits parameters (`kw`-> `keyword`, `a`-> `addresses`) and make them consistent with implementations
- add generic `WORD_LENGTH` on `test_utils` functions (functions that are actually used on HTTP client & KMS encryption layer implementations 
- upgrades rand crates (`rand`, `rand_chacha` and `rand_core`)