### PR TITLE
[4]Feat/postgrestore

### DIFF
--- a/.github/workflows/hack.yml
+++ b/.github/workflows/hack.yml
@@ -7,6 +7,19 @@ jobs:
   hack:
     runs-on: ubuntu-latest
     services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: cosmian
+          POSTGRES_PASSWORD: cosmian
+          POSTGRES_DB: cosmian
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
       redis:
         image: redis
         options: >-

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 pkg/
+.cargo_check/
 target/
 **/Cargo.lock
 perf*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rust-mem = []
 redis-mem = ["redis"]
 sqlite-mem = ["async-sqlite"]
 test-utils = ["tokio", "criterion", "futures", "rand", "rand_distr"]
+postgres-mem = ["tokio-postgres", "tokio/rt-multi-thread", "deadpool-postgres"]
 
 [dependencies]
 aes = "0.8"
@@ -40,11 +41,15 @@ tokio = { version = "1.44", features = ["rt", "rt-multi-thread"], optional = tru
 
 # Memory dependencies
 async-sqlite = { version = "0.5", optional = true }
+deadpool-postgres = { version = "0.14.1", optional = true }
 redis = { version = "0.28", features = [
     "aio",
     "connection-manager",
     "tokio-comp",
 ], optional = true }
+tokio-postgres = { version = "0.7.9", optional = true, features = [
+    "array-impls",
+] }
 
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,9 @@ pub use memory::{RedisMemory, RedisMemoryError};
 #[cfg(feature = "sqlite-mem")]
 pub use memory::{SqliteMemory, SqliteMemoryError};
 
+#[cfg(feature = "postgres-mem")]
+pub use memory::{PostgresMemory, PostgresMemoryError};
+
 #[cfg(any(test, feature = "test-utils"))]
 pub use encoding::{
     dummy_encoding::{WORD_LENGTH, dummy_decode, dummy_encode},

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -12,6 +12,11 @@ mod redis_store;
 pub use redis_store::{RedisMemory, RedisMemoryError};
 
 #[cfg(feature = "sqlite-mem")]
-pub mod sqlite_store;
+mod sqlite_store;
 #[cfg(feature = "sqlite-mem")]
 pub use sqlite_store::{SqliteMemory, SqliteMemoryError};
+
+#[cfg(feature = "postgres-mem")]
+mod postgresql_store;
+#[cfg(feature = "postgres-mem")]
+pub use postgresql_store::{PostgresMemory, PostgresMemoryError};

--- a/src/memory/postgresql_store/error.rs
+++ b/src/memory/postgresql_store/error.rs
@@ -1,0 +1,82 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum PostgresMemoryError {
+    TokioPostgresError(deadpool_postgres::tokio_postgres::Error),
+    TryFromSliceError(std::array::TryFromSliceError),
+    BuildPoolError(deadpool_postgres::BuildError),
+    GetConnectionFromPoolError(deadpool_postgres::PoolError),
+    PoolConfigError(deadpool_postgres::ConfigError),
+    RetryExhaustedError(usize),
+    InvalidDataLength(usize),
+    TableCreationError(u64),
+}
+
+impl std::error::Error for PostgresMemoryError {}
+
+impl fmt::Display for PostgresMemoryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TokioPostgresError(err) => write!(f, "tokio-postgres error: {}", err),
+            Self::TryFromSliceError(err) => write!(f, "try_from_slice error: {}", err),
+            Self::InvalidDataLength(len) => {
+                write!(
+                    f,
+                    "invalid data length: received {} bytes from db instead of WORD_LENGTH bytes",
+                    len
+                )
+            }
+            Self::PoolConfigError(err) => {
+                write!(f, "deadpool_postgres error during pool creation: {}", err)
+            }
+            Self::BuildPoolError(err) => {
+                write!(f, "deadpool_postgres error during pool build: {}", err)
+            }
+            Self::GetConnectionFromPoolError(err) => write!(
+                f,
+                "deadpool_postgres error while trying to get a connection from the pool: {}",
+                err
+            ),
+            Self::RetryExhaustedError(retries) => {
+                write!(f, "retries exhausted after {} attempts", retries)
+            }
+            Self::TableCreationError(err) => {
+                write!(
+                    f,
+                    "error creating table, {} rows returned while 0 were expected.",
+                    err
+                )
+            }
+        }
+    }
+}
+
+impl From<deadpool_postgres::tokio_postgres::Error> for PostgresMemoryError {
+    fn from(err: deadpool_postgres::tokio_postgres::Error) -> Self {
+        Self::TokioPostgresError(err)
+    }
+}
+
+impl From<std::array::TryFromSliceError> for PostgresMemoryError {
+    fn from(err: std::array::TryFromSliceError) -> Self {
+        Self::TryFromSliceError(err)
+    }
+}
+
+impl From<deadpool_postgres::ConfigError> for PostgresMemoryError {
+    fn from(err: deadpool_postgres::ConfigError) -> Self {
+        Self::PoolConfigError(err)
+    }
+}
+
+impl From<deadpool_postgres::BuildError> for PostgresMemoryError {
+    fn from(err: deadpool_postgres::BuildError) -> Self {
+        Self::BuildPoolError(err)
+    }
+}
+
+impl From<deadpool_postgres::PoolError> for PostgresMemoryError {
+    fn from(err: deadpool_postgres::PoolError) -> Self {
+        Self::GetConnectionFromPoolError(err)
+    }
+}

--- a/src/memory/postgresql_store/memory.rs
+++ b/src/memory/postgresql_store/memory.rs
@@ -1,0 +1,338 @@
+use super::PostgresMemoryError;
+use crate::{Address, MemoryADT};
+use deadpool_postgres::Pool;
+use std::marker::PhantomData;
+use tokio_postgres::{
+    Socket,
+    tls::{MakeTlsConnect, TlsConnect},
+};
+
+#[derive(Clone, Debug)]
+pub struct PostgresMemory<Address, Word> {
+    pool: Pool,
+    table_name: String,
+    _marker: PhantomData<(Address, Word)>,
+}
+
+impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize>
+    PostgresMemory<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>
+{
+    /// Connect to a Postgres database and create a table if it doesn't exist
+    pub async fn initialize_table<T>(
+        &self,
+        db_url: String,
+        table_name: String,
+        tls: T,
+    ) -> Result<(), PostgresMemoryError>
+    where
+        T: MakeTlsConnect<Socket> + Send,
+        T::Stream: Send + 'static,
+        T::TlsConnect: Send,
+        <T::TlsConnect as TlsConnect<Socket>>::Future: Send,
+    {
+        let (client, connection) = tokio_postgres::connect(&db_url, tls).await?;
+
+        // The connection object performs the actual communication with the database
+        // `Connection` only resolves when the connection is closed, either because a fatal error has
+        // occurred, or because its associated `Client` has dropped and all outstanding work has completed.
+        let conn_handle = tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+
+        let returned = client
+            .execute(
+                &format!(
+                    "
+                    CREATE TABLE IF NOT EXISTS {} (
+                        a BYTEA PRIMARY KEY CHECK (octet_length(a) = {}),
+                        w BYTEA NOT NULL CHECK (octet_length(w) = {})
+                    );",
+                    table_name, ADDRESS_LENGTH, WORD_LENGTH
+                ),
+                &[],
+            )
+            .await?;
+        if returned != 0 {
+            return Err(PostgresMemoryError::TableCreationError(returned));
+        }
+
+        drop(client);
+        let _ = conn_handle.await; // ensures that the connection is closed
+        Ok(())
+    }
+
+    /// Connect to a Postgres database and create a table if it doesn't exist
+    pub async fn connect_with_pool(
+        pool: Pool,
+        table_name: String,
+    ) -> Result<Self, PostgresMemoryError> {
+        Ok(Self {
+            pool,
+            table_name,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
+    for PostgresMemory<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>
+{
+    type Address = Address<ADDRESS_LENGTH>;
+    type Word = [u8; WORD_LENGTH];
+    type Error = PostgresMemoryError;
+
+    async fn batch_read(
+        &self,
+        addresses: Vec<Self::Address>,
+    ) -> Result<Vec<Option<Self::Word>>, Self::Error> {
+        let client = self.pool.get().await?;
+        // in psql, statements are cached per connection and not per pool
+        let stmt = client
+            .prepare_cached(
+                format!(
+                    "SELECT f.w
+                        FROM UNNEST($1::bytea[]) WITH ORDINALITY AS params(addr, idx)
+                        LEFT JOIN {} f ON params.addr = f.a
+                        ORDER BY params.idx;",
+                    self.table_name
+                )
+                .as_str(),
+            )
+            .await?;
+
+        client
+            // the left join is necessary to ensure that the order of the addresses is preserved
+            // as well as to return None for addresses that don't exist
+            .query(
+                &stmt,
+                &[&addresses
+                    .iter()
+                    .map(|addr| addr.as_slice())
+                    .collect::<Vec<_>>()],
+            )
+            .await?
+            .iter()
+            .map(|row| {
+                let bytes_slice: Option<&[u8]> = row.try_get("w")?; // `row.get(0)` can panic
+                bytes_slice.map_or(Ok(None), |slice| {
+                    slice
+                        .try_into()
+                        .map(Some)
+                        .map_err(|_| PostgresMemoryError::InvalidDataLength(slice.len()))
+                })
+            })
+            .collect()
+    }
+
+    async fn guarded_write(
+        &self,
+        guard: (Self::Address, Option<Self::Word>),
+        bindings: Vec<(Self::Address, Self::Word)>,
+    ) -> Result<Option<Self::Word>, Self::Error> {
+        let g_write_script = format!(
+            "
+        WITH
+        guard_check AS (
+            SELECT w FROM {0} WHERE a = $1::bytea
+        ),
+        dedup_input_table AS (
+        SELECT DISTINCT ON (a) a, w
+            FROM UNNEST($3::bytea[], $4::bytea[]) WITH ORDINALITY AS t(a, w, order_idx)
+            ORDER BY a, order_idx DESC
+        ),
+        insert_cte AS (
+            INSERT INTO {0} (a, w)
+            SELECT a, w FROM dedup_input_table AS t(a,w)
+            WHERE (
+                $2::bytea IS NULL AND NOT EXISTS (SELECT 1 FROM guard_check)
+            ) OR (
+                $2::bytea IS NOT NULL AND EXISTS (
+                    SELECT 1 FROM guard_check WHERE w = $2::bytea
+                )
+            )
+            ON CONFLICT (a) DO UPDATE SET w = EXCLUDED.w
+        )
+        SELECT COALESCE((SELECT w FROM guard_check)) AS original_guard_value;",
+            self.table_name
+        );
+
+        let (addresses, words): (Vec<[u8; ADDRESS_LENGTH]>, Vec<Self::Word>) =
+            bindings.into_iter().map(|(a, w)| (*a, w)).unzip();
+        const MAX_RETRIES: usize = 10;
+
+        for _ in 0..MAX_RETRIES {
+            // while counterintuitive, getting a new client on each retry is a better approach
+            // than trying to reuse the same client since it allows other operations to use the
+            // connection between retries.
+            let mut client = self.pool.get().await?;
+            let stmt = client.prepare_cached(g_write_script.as_str()).await?;
+
+            let result = async {
+                // Start transaction with SERIALIZABLE isolation
+                let tx = client
+                    .build_transaction()
+                    .isolation_level(
+                        deadpool_postgres::tokio_postgres::IsolationLevel::Serializable,
+                    )
+                    .start()
+                    .await?;
+
+                let res = tx
+                    .query_opt(
+                        &stmt,
+                        &[
+                            &*guard.0,
+                            &guard.1.as_ref().map(|w| w.as_slice()),
+                            &addresses,
+                            &words,
+                        ],
+                    )
+                    .await?
+                    .map_or(
+                        Ok::<Option<[u8; WORD_LENGTH]>, PostgresMemoryError>(None),
+                        |row| {
+                            row.try_get::<_, Option<&[u8]>>(0)?
+                                .map_or(Ok(None), |r| Ok(Some(r.try_into()?)))
+                        },
+                    )?;
+                tx.commit().await?;
+                Ok(res)
+            }
+            .await;
+            match result {
+                Ok(value) => return Ok(value),
+                Err(err) => {
+                    // Retry on serialization failures (error code 40001), otherwise fail and return the error
+                    if let PostgresMemoryError::TokioPostgresError(pg_err) = &err {
+                        if pg_err.code().is_some_and(|code| code.code() == "40001") {
+                            continue;
+                        }
+                    }
+                    return Err(err);
+                }
+            }
+        }
+        Err(PostgresMemoryError::RetryExhaustedError(MAX_RETRIES))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use deadpool_postgres::Config;
+    use tokio_postgres::NoTls;
+
+    use super::*;
+    use crate::{
+        ADDRESS_LENGTH, Address, WORD_LENGTH, gen_seed, test_guarded_write_concurrent,
+        test_rw_same_address, test_single_write_and_read, test_wrong_guard,
+    };
+
+    const DB_URL: &str = "postgres://cosmian:cosmian@localhost/cosmian";
+
+    // Template function for pool creation
+    pub async fn create_testing_pool(db_url: &str) -> Result<Pool, PostgresMemoryError> {
+        let mut pg_config = Config::new();
+        pg_config.url = Some(db_url.to_string());
+        let pool = pg_config.builder(NoTls)?.build()?;
+        Ok(pool)
+    }
+
+    // Setup function that handles pool creation, memory initialization, test execution, and cleanup
+    async fn setup_and_run_test<F, Fut>(
+        table_name: &str,
+        test_fn: F,
+    ) -> Result<(), PostgresMemoryError>
+    where
+        F: FnOnce(PostgresMemory<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>) -> Fut + Send,
+        Fut: std::future::Future<Output = ()> + Send,
+    {
+        let test_pool = create_testing_pool(DB_URL).await.unwrap();
+        let m = PostgresMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect_with_pool(
+            test_pool.clone(),
+            table_name.to_string(),
+        )
+        .await?;
+
+        m.initialize_table(DB_URL.to_string(), table_name.to_string(), NoTls)
+            .await?;
+
+        test_fn(m).await;
+
+        // Cleanup - drop the table to avoid flacky tests
+        test_pool
+            .get()
+            .await?
+            .execute(&format!("DROP table {};", table_name), &[])
+            .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_initialization() -> Result<(), PostgresMemoryError> {
+        let table_name: &str = "test_initialization";
+        let test_pool = create_testing_pool(DB_URL).await.unwrap();
+        let m = PostgresMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect_with_pool(
+            test_pool.clone(),
+            table_name.to_string(),
+        )
+        .await?;
+
+        m.initialize_table(DB_URL.to_string(), table_name.to_string(), NoTls)
+            .await?;
+
+        // check that the table actually exists
+        let client = test_pool.get().await?;
+        let returned = client
+            .query(
+                "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'test_initialization';",
+                &[],
+            )
+            .await?;
+
+        assert_eq!(returned[0].get::<_, i64>(0), 1);
+
+        // Cleanup - drop the table to avoid flacky tests
+        test_pool
+            .get()
+            .await?
+            .execute(&format!("DROP table {table_name};"), &[])
+            .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_rw_seq() -> Result<(), PostgresMemoryError> {
+        setup_and_run_test("findex_test_rw_seq", |m| async move {
+            test_single_write_and_read::<WORD_LENGTH, _>(&m, gen_seed()).await;
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_guard_seq() -> Result<(), PostgresMemoryError> {
+        setup_and_run_test("findex_test_guard_seq", |m| async move {
+            test_wrong_guard::<WORD_LENGTH, _>(&m, gen_seed()).await;
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_rw_same_address_seq() -> Result<(), PostgresMemoryError> {
+        setup_and_run_test("findex_test_rw_same_address_seq", |m| async move {
+            test_rw_same_address::<WORD_LENGTH, _>(&m, gen_seed()).await;
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_rw_ccr() -> Result<(), PostgresMemoryError> {
+        setup_and_run_test("findex_test_rw_ccr", |m| async move {
+            test_guarded_write_concurrent::<WORD_LENGTH, _>(&m, gen_seed(), Some(100)).await;
+        })
+        .await
+    }
+}

--- a/src/memory/postgresql_store/mod.rs
+++ b/src/memory/postgresql_store/mod.rs
@@ -1,0 +1,5 @@
+mod error;
+mod memory;
+
+pub use error::PostgresMemoryError;
+pub use memory::PostgresMemory;

--- a/src/memory/sqlite_store.rs
+++ b/src/memory/sqlite_store.rs
@@ -14,7 +14,6 @@ use std::{
 pub enum SqliteMemoryError {
     AsyncSqliteError(async_sqlite::Error),
 }
-
 impl std::error::Error for SqliteMemoryError {}
 
 impl fmt::Display for SqliteMemoryError {

--- a/src/memory/sqlite_store.rs
+++ b/src/memory/sqlite_store.rs
@@ -14,6 +14,7 @@ use std::{
 pub enum SqliteMemoryError {
     AsyncSqliteError(async_sqlite::Error),
 }
+
 impl std::error::Error for SqliteMemoryError {}
 
 impl fmt::Display for SqliteMemoryError {


### PR DESCRIPTION


## Artifacts : 

### Batch_Read : 

This is the "simpler" version of batch_read
It is 20% slower but the code is easier

```rust
    async fn batch_read(
        &self,
        addresses: Vec<Self::Address>,
    ) -> Result<Vec<Option<Self::Word>>, Self::Error> {
        let client = self.pool.get().await?;
        // in Postgres databases, statements are cached per connection and not per pool
        let stmt = client
            .prepare_cached(
                format!(
                    "SELECT a,w
                    FROM {0}
                    WHERE a = ANY($1::bytea[])
                    ;",
                    self.table_name
                )
                .as_str(),
            )
            .await?;

        let results = client
            .query(&stmt, &[&addresses
                .iter()
                .map(|addr| addr.as_slice())
                .collect::<Vec<_>>()])
            .await?
            .iter()
            .map(|row| {
                // TODO: REMOVE UNWRAP AND IMPLEMENT THE NECESSARY ERROR HANDLING
                let a = Address::from(
                    <&[u8] as TryInto<[u8; ADDRESS_LENGTH]>>::try_into(row.try_get("a").unwrap())
                        .unwrap(),
                );
                let w: Self::Word = row.try_get::<_, &[u8]>("w").unwrap().try_into().unwrap();
                (a, w)
            })
            .collect::<HashMap<_, _>>();

        Ok(addresses
            .iter()
            // Copying is necessary here since the same word could be returned multiple times.
            .map(|addr| results.get(addr).copied())
            .collect())
    }
```

## Benching batch_read : 

The following test helps run barch_read multiple times with the help of the below companion script

Test : 
```rust
    fn gen_bytes<const BYTES_LENGTH: usize>(rng: &mut impl RngCore) -> [u8; BYTES_LENGTH] {
        let mut bytes = [0; BYTES_LENGTH];
        rng.fill_bytes(&mut bytes);
        bytes
    }
    #[tokio::test]
    async fn bench_batch_read() -> Result<(), PostgresMemoryError> {
        setup_and_run_test("findex_bench_batch_read", |m| async move {
            const NUM_ADDRESSES: usize = 100;
            const NUM_ITERATIONS: usize = 1000;
            let mut rng = StdRng::from_seed([0; KEY_LENGTH]);

            // Generate random addresses
            let addresses: Vec<Address<ADDRESS_LENGTH>> = (0..NUM_ADDRESSES)
                .map(|_| Address::from(gen_bytes::<ADDRESS_LENGTH>(&mut rng)))
                .collect();

            // Pre-write data to all addresses
            for address in &addresses {
                let word = gen_bytes::<WORD_LENGTH>(&mut rng);
                m.guarded_write((address.clone(), None), vec![(address.clone(), word)])
                    .await
                    .unwrap();
            }

            // Benchmark batch reads
            let start = tokio::time::Instant::now();
            for _ in 0..NUM_ITERATIONS {
                m.batch_read(addresses.clone()).await.unwrap();
            }
            let elapsed = start.elapsed();

            println!("BENCHMARK_TIME:{}:", elapsed.as_millis());
        })
        .await
    }
```

Script : 
```bash
#!/bin/bash               
total=0
count=40 # feel free to edit this
for ((i=1; i<=count; i++)); do
    time_ms=$(cargo test bench_batch_read --features postgres-mem --release -- --nocapture 2>&1 | grep 'BENCHMARK_TIME:' | awk -F: '{print $2}')
    if [ -n "$time_ms" ]; then
        total=$((total + time_ms))
        echo "Run $i: $time_ms ms"
    else
        echo "Run $i: Failed to capture time"
    fi
done
if [ $total -ne 0 ]; then
    average=$((total / count))
    echo "Average time over $count runs: $average ms"
else
    echo "No valid measurements were captured"
fi
```

## Performed tests

#### Performance : would using the hstore module be better ?
In theory : 🚫  | Test : (not done)

The answer was no, for the followng reasons : 
- B-tree indexes offer is faster lookups vs hstore GIN [src](https://www.postgresql.org/message-id/D83E55F5F4D99B4A9B4C4E259E6227CD014F995C@AUX1EXC02.apac.experian.local)
- Row-level locking enables higher concurrency than document-level


### Performance : would using another index improve perf ?
In theory : 🆗  | Test : 🚫 

No. In theory, HASH index would increase performance however after testing we notice that the tests become around 10% slower (probably due to indexing overhead ?) so it is better to leave default values as they are

### Performance : would using prepared statement perf ?
In theory : 🆗  | Test : 🚀 🆗 

using prepared statements improved performance by around a **huge x5** ! making it comparable with sqlite3 interface

Prepared statements are a good idea since they benefit from caching and remove request processing overhead, which is very useful with our requests that are particularely complex and have a lot of CTE

### Performance : fillfactor ?
In theory : 🚫  | Test : ?

Let's think about what the fillfactor serves : avoiding fragmentation problems when we do frequent update. GWrite is subject to do frequent updates on certain scenarios.
However, the WORD_LENGTH is fixed, meaning no update will ever cause fragmentation issues because the "new data" will always have fixed size ! so in theory, the fillfactor should stay 100% like the default. For reasons that are yet not known, a small perf increase was seen with FILLFACTOR set to 90%

### Performance : storage mode and compression
In theory : 🆗  | Test : Nothing changed

EXTERNAL storage mode stores data out-of-line in a secondary TOAST table but does not compress it
This is pretty cummon tu use with BYTEA values that do not benefit from compression (cpu sees that the compressed data is bigger than the original data and cancels the compression, which is a waste of cpu time - [source and benches](https://www.cybertec-postgresql.com/en/binary-data-performance-in-postgresql/#alternatives-for-storing-binary-data) )

However, changing those parameters didn't make the tests run faster.

PS : the consisty garantees are **not** violated with this storage method


### Alt approach

This is (for reference only) an alternative approach to do G_write

I has, however, poor performance. So similar approaches are to be avoided ( 857.55s, instead of 120 for 1000 workers )

```rust

        let (ag, wg) = (guard.0, guard.1.as_ref().map(|w| &w[..]));

        let params = match &wg {
            Some(guard) => vec![&*ag as &(dyn ToSql + Sync), guard],
            None => vec![&*ag, &None::<&[u8]> as &(dyn ToSql + Sync)],
        }
        .iter()
        .copied()
        .chain(bindings.iter().flat_map(|(a, w)| vec![&**a as _, &*w as _]))
        .collect::<Vec<&(dyn ToSql + Sync)>>();

        let query = &format!(
            "
    WITH
    guard_check AS (
        SELECT w FROM findex_db WHERE a = $1::bytea
    ),
    insert_condition AS (
        INSERT INTO findex_db (a, w)
        SELECT * FROM (
            VALUES
            {}
        ) AS new_values(a, w)
WHERE (
    $2::bytea IS NULL AND NOT EXISTS (SELECT 1 FROM guard_check)
) OR (
    $2::bytea IS NOT NULL AND EXISTS (
       SELECT 1 FROM guard_check WHERE w = $2::bytea
    )
)
        ON CONFLICT (a) DO UPDATE SET w = EXCLUDED.w
    )
    SELECT COALESCE((SELECT w FROM guard_check)) AS original_guard_value;
",
            (3..=params.len())
                .step_by(2) // params.len() is always even
                .map(|i| format!("(${}::bytea, ${}::bytea)", i, i + 1))
                .collect::<Vec<String>>()
                .join(",")
        );
        self.client
            .query_opt(query, &params)
            .await?
            .map_or(Ok(None), |row| {
                row.try_get::<_, Option<&[u8]>>(0)?
                    .map(|b| b.try_into())
                    .map_or(Ok(None), |r| Ok(Some(r?)))
            })
```