### PR TITLE
Test/collisions

### DIFF
--- a/src/adt/test_utils.rs
+++ b/src/adt/test_utils.rs
@@ -174,7 +174,7 @@ pub async fn test_rw_same_address<const WORD_LENGTH: usize, Memory>(
     );
 
     // try to write multiple values to the same address with a guard that should pass
-    let values = (1..REPETITION)
+    let values = (0..REPETITION)
         .map(|_| Memory::Word::from(gen_bytes(&mut rng)))
         .collect::<Vec<_>>();
     let same_adr_write = memory

--- a/src/adt/test_utils.rs
+++ b/src/adt/test_utils.rs
@@ -132,6 +132,80 @@ pub async fn test_wrong_guard<const WORD_LENGTH: usize, Memory>(
     );
 }
 
+/// Tests operations on repeated addresses in memory implementations.
+///
+/// This test verifies the behavior when the same address is used multiple times:
+/// 1. Writes a value to an address and then confirms it can be read back multiple times consistently
+/// 2. Performs multiple writes to the same address with a correct guard
+/// 3. Verifies that one of the written values is properly stored
+pub async fn test_rw_same_address<const WORD_LENGTH: usize, Memory>(
+    memory: &Memory,
+    seed: [u8; KEY_LENGTH],
+) where
+    Memory: Send + Sync + MemoryADT,
+    Memory::Address: Send + Clone + From<[u8; ADDRESS_LENGTH]>,
+    Memory::Word: Send + Debug + Clone + PartialEq + From<[u8; WORD_LENGTH]>,
+    Memory::Error: Send + std::error::Error,
+{
+    const REPETITION: usize = 5;
+    let mut rng = StdRng::from_seed(seed);
+
+    let a = Memory::Address::from(gen_bytes(&mut rng));
+    let w = Memory::Word::from(gen_bytes(&mut rng));
+
+    memory
+        .guarded_write((a.clone(), None), vec![(a.clone(), w.clone())])
+        .await
+        .unwrap();
+
+    // try to read that same address multiple times
+    let read_result = memory
+        .batch_read(vec![a.clone(); REPETITION])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        read_result,
+        vec![Some(w.clone()); REPETITION],
+        "test_collisions failed. Expected all reads to return the same value. Got : {:?}. Debug \
+         seed : {:?}",
+        read_result,
+        seed
+    );
+
+    // try to write multiple values to the same address with a guard that should pass
+    let values = (1..REPETITION)
+        .map(|_| Memory::Word::from(gen_bytes(&mut rng)))
+        .collect::<Vec<_>>();
+    let same_adr_write = memory
+        .guarded_write(
+            (a.clone(), Some(w.clone())),
+            (0..values.len())
+                .map(|i| (a.clone(), values[i].clone()))
+                .collect::<Vec<_>>(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        same_adr_write,
+        Some(w.clone()),
+        "test_wrong_guard failed.\nExpected value {:?} after write. Got : {:?}.\nDebug seed : {:?}",
+        same_adr_write,
+        Some(w),
+        seed
+    );
+
+    let written_value = memory.batch_read(vec![a.clone()]).await.unwrap();
+
+    assert!(
+        values.iter().any(|v| Some(v.clone()) == written_value[0]),
+        "Value not found in the written values list. Got: {:?}, Values: {:?}",
+        written_value,
+        values
+    );
+}
+
 /// Tests concurrent guarded write operations on a Memory ADT implementation.
 ///
 /// Spawns multiple threads to perform concurrent counter increments.

--- a/src/memory/redis_store.rs
+++ b/src/memory/redis_store.rs
@@ -142,7 +142,8 @@ mod tests {
     use crate::{
         WORD_LENGTH,
         adt::test_utils::{
-            test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard,
+            test_guarded_write_concurrent, test_rw_same_address, test_single_write_and_read,
+            test_wrong_guard,
         },
     };
 
@@ -154,23 +155,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rw_seq() -> Result<(), RedisMemoryError> {
+    async fn test_rw_seq() {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_single_write_and_read::<WORD_LENGTH, _>(&m, rand::random()).await;
-        Ok(())
+        test_single_write_and_read::<WORD_LENGTH, _>(&m, rand::random()).await
     }
 
     #[tokio::test]
-    async fn test_guard_seq() -> Result<(), RedisMemoryError> {
+    async fn test_guard_seq() {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_wrong_guard::<WORD_LENGTH, _>(&m, rand::random()).await;
-        Ok(())
+        test_wrong_guard::<WORD_LENGTH, _>(&m, rand::random()).await
     }
 
     #[tokio::test]
-    async fn test_rw_ccr() -> Result<(), RedisMemoryError> {
+    async fn test_collision_seq() {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_guarded_write_concurrent::<WORD_LENGTH, _>(&m, rand::random(), None).await;
-        Ok(())
+        test_rw_same_address::<WORD_LENGTH, _>(&m, rand::random()).await
+    }
+
+    #[tokio::test]
+    async fn test_rw_ccr() {
+        let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
+        test_guarded_write_concurrent::<WORD_LENGTH, _>(&m, rand::random(), None).await
     }
 }

--- a/src/memory/sqlite_store.rs
+++ b/src/memory/sqlite_store.rs
@@ -91,7 +91,7 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
     ) -> Result<Vec<Option<Self::Word>>, Self::Error> {
         self.pool
             .conn(move |conn| {
-                let mut bindings = conn
+                let results = conn
                     .prepare(&format!(
                         "SELECT a, w FROM memory WHERE a IN ({})",
                         vec!["?"; addresses.len()].join(",")
@@ -109,7 +109,10 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
                 // Return order of an SQL select statement is undefined, and
                 // mismatches are ignored. A post-processing is thus needed to
                 // generate a returned value complying to the batch-read spec.
-                Ok(addresses.iter().map(|addr| bindings.remove(addr)).collect())
+                Ok(addresses
+                    .iter()
+                    .map(|addr| results.get(addr).copied()) // no way to avoid copying here
+                    .collect())
             })
             .await
             .map_err(Self::Error::from)
@@ -162,33 +165,42 @@ mod tests {
     use crate::{
         ADDRESS_LENGTH, WORD_LENGTH,
         adt::test_utils::{
-            test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard,
+            test_guarded_write_concurrent, test_rw_same_address, test_single_write_and_read,
+            test_wrong_guard,
         },
     };
 
     const DB_PATH: &str = "./target/debug/sqlite-test.db";
 
     #[tokio::test]
-    async fn test_rw_seq() -> Result<(), SqliteMemoryError> {
-        let m =
-            SqliteMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect(DB_PATH).await?;
-        test_single_write_and_read(&m, rand::random()).await;
-        Ok(())
+    async fn test_rw_seq() {
+        let m = SqliteMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect(DB_PATH)
+            .await
+            .unwrap();
+        test_single_write_and_read(&m, rand::random()).await
     }
 
     #[tokio::test]
-    async fn test_guard_seq() -> Result<(), SqliteMemoryError> {
-        let m =
-            SqliteMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect(DB_PATH).await?;
-        test_wrong_guard(&m, rand::random()).await;
-        Ok(())
+    async fn test_guard_seq() {
+        let m = SqliteMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect(DB_PATH)
+            .await
+            .unwrap();
+        test_wrong_guard(&m, rand::random()).await
     }
 
     #[tokio::test]
-    async fn test_rw_ccr() -> Result<(), SqliteMemoryError> {
-        let m =
-            SqliteMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect(DB_PATH).await?;
-        test_guarded_write_concurrent(&m, rand::random(), Some(100)).await;
-        Ok(())
+    async fn test_collision_seq() {
+        let m = SqliteMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect(DB_PATH)
+            .await
+            .unwrap();
+        test_rw_same_address(&m, rand::random()).await
+    }
+
+    #[tokio::test]
+    async fn test_rw_ccr() {
+        let m = SqliteMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect(DB_PATH)
+            .await
+            .unwrap();
+        test_guarded_write_concurrent(&m, rand::random(), Some(100)).await
     }
 }

--- a/src/memory/sqlite_store.rs
+++ b/src/memory/sqlite_store.rs
@@ -111,7 +111,8 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
                 // generate a returned value complying to the batch-read spec.
                 Ok(addresses
                     .iter()
-                    .map(|addr| results.get(addr).copied()) // no way to avoid copying here
+                    // Copying is necessary here since the same word could be returned multiple times.
+                    .map(|addr| results.get(addr).copied())
                     .collect())
             })
             .await


### PR DESCRIPTION
## ℹ️ PR ORDER ℹ️ 

Develops <- #128 <-  #126 <- #129 

## ⚠️ UPDATE 1: Add address collision test to MemoryADT test suite

This PR adds the `test_collisions` test to verify that memory implementations correctly handle multiple writes to the same address in a single guarded write operation.

### Problem
Some memory implementations may handle multiple writes to the same address in an inconsistent or non-deterministic manner when these writes occur within a single `guarded_write` call. The MemoryADT interface should instead require that when multiple writes target the same address, the last write should take precedence.

This test guarantees consistent behavior across all implementations of the MemoryADT interface.

### Example
```rust
// Write multiple values to the same address in one operation
memory.guarded_write(
    (address, guard), 
    [
        (address, value1),
        (address, value2),
        (address, value3),
        // ...
        (address, lastValue)
    ]
)

// Read should always return the last value
let result = memory.batch_read([address]);
assert_eq!(result, [Some(lastValue)]);
```

## UPDATE 2: Fix sqlite3 batch_read

In the previous version, using `bindings.remove` (renamed to results for better readability) deletes (ie : moves) the value out of the hashmap, so if we had retrieved the same value multiple time, we will encounter a failure. Hence, we need to copy. There is not way of escaping the copy : 

By Exhaustion
- Borrowing: Not possible because the references would outlive their source (results HashMap).
- Moving: Not possible because **get**() only provides references, and **remove** fails the required logic as explained
- Copying/Cloning: The only remaining option. And a copy is still less expensive than a Clone.
