### PR TITLE
[2]feat: use tostring to easy guard condition

### DIFF
--- a/src/memory/redis_store.rs
+++ b/src/memory/redis_store.rs
@@ -13,7 +13,7 @@ local guard_word    = ARGV[2]
 local length        = ARGV[3]
 local current_word  = redis.call('GET',guard_address)
 
--- If no value is found, nil is converted to 'false'.
+-- If no word is found, nil is converted to 'false'.
 if guard_word == tostring(current_word) then
     for i = 4,(length*2)+3,2
     do


### PR DESCRIPTION
This PR fixes a very complicated bug that happens when benching the redis interface.

TL;DR : when we flush the DB while it still has pending write operations to perform, the value==false condition can be triggered leaving to an inconsistent state.

I got rid of (value == false) by converting everything to string using built-in **tostring** function available in LUA

Reminder : as a design choice made in the MemoryADT implementation for Redis, we map None guards to a binary false ( see line 126 of redis_store.rs ).

In the previous code, the guard_value == value check was not sufficient because when there is "no guard", it will be comparing nil to b"false", which valuates to false (we don't want that). This is why value==false check was necessary (in LUA nil **always** evaluates to false, so comparing nil to a binary false will yield **true** .

Also, as far as I know, there is no way to pass nil directily via rust

So this method does the trick ( PS : the benches do pass 🥳 The workflow was tested here : https://github.com/Cosmian/findex/actions/runs/14335731155/job/40182250331 )


PS : an issue was opening to redis-rs about this topic : https://github.com/redis-rs/redis-rs/issues/1605