### PR TITLE
chore: less dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,14 @@ jobs:
   cargo-lint:
     uses: Cosmian/reusable_workflows/.github/workflows/cargo-nursery.yml@develop
     with:
-      toolchain: stable
+      toolchain: 1.85.0
   cargo-publish:
     needs:
       - cargo-lint
     uses: Cosmian/reusable_workflows/.github/workflows/cargo-publish.yml@develop
     if: startsWith(github.ref, 'refs/tags/')
     with:
-      toolchain: stable
+      toolchain: 1.85.0
     secrets: inherit
   cleanup:
     needs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ path = "src/lib.rs"
 rust-mem = []
 redis-mem = ["redis"]
 sqlite-mem = ["async-sqlite"]
-test-utils = ["tokio", "criterion", "rand", "rand_distr"]
-postgres-mem = ["tokio-postgres", "tokio", "deadpool-postgres"]
+test-utils = ["criterion", "rand", "rand_distr", "agnostic/tokio"]
+postgres-mem = ["tokio-postgres", "deadpool-postgres"]
 
 [dependencies]
 aes = "0.8"
@@ -39,7 +39,6 @@ xts-mode = "0.5"
 criterion = { version = "0.6", optional = true }
 rand = { version = "0.9.0", optional = true }
 rand_distr = { version = "0.5.1", optional = true }
-tokio = { version = "1.44", features = ["rt-multi-thread"], optional = true }
 
 # Memory dependencies
 async-sqlite = { version = "0.5", optional = true }
@@ -52,9 +51,11 @@ redis = { version = "0.28", features = [
 tokio-postgres = { version = "0.7.9", features = [
     "array-impls",
 ], optional = true }
+agnostic = { version = "0.7", optional = true, features = ["tokio", "smol"] }
 
 
 [dev-dependencies]
+agnostic = { version = "0.7", features = ["tokio", "smol"] }
 tokio = { version = "1.44", features = ["macros", "rt-multi-thread"] }
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/lib.rs"
 rust-mem = []
 redis-mem = ["redis"]
 sqlite-mem = ["async-sqlite"]
-test-utils = ["criterion", "rand", "rand_distr"]
+test-utils = ["tokio", "criterion", "rand", "rand_distr"]
 postgres-mem = ["tokio-postgres", "tokio", "deadpool-postgres"]
 
 [dependencies]
@@ -39,6 +39,7 @@ xts-mode = "0.5"
 criterion = { version = "0.6", optional = true }
 rand = { version = "0.9.0", optional = true }
 rand_distr = { version = "0.5.1", optional = true }
+tokio = { version = "1.44", features = ["rt-multi-thread"], optional = true }
 
 # Memory dependencies
 async-sqlite = { version = "0.5", optional = true }
@@ -48,7 +49,6 @@ redis = { version = "0.28", features = [
     "connection-manager",
     "tokio-comp",
 ], optional = true }
-tokio = { version = "1.44", features = ["rt-multi-thread"], optional = true }
 tokio-postgres = { version = "0.7.9", features = [
     "array-impls",
 ], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ cosmian_crypto_core = { version = "10.1", default-features = false, features = [
 xts-mode = "0.5"
 
 # Used in benches and tests.
-criterion = { version = "0.5", optional = true }
+criterion = { version = "0.6", optional = true }
 rand = { version = "0.9.0", optional = true }
 rand_distr = { version = "0.5.1", optional = true }
 tokio = { version = "1.44", features = ["rt-multi-thread"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/lib.rs"
 rust-mem = []
 redis-mem = ["redis"]
 sqlite-mem = ["async-sqlite"]
-test-utils = ["tokio", "criterion", "futures", "rand", "rand_distr"]
+test-utils = ["tokio", "criterion", "rand", "rand_distr"]
 postgres-mem = ["tokio-postgres", "tokio", "deadpool-postgres"]
 
 [dependencies]
@@ -37,7 +37,6 @@ xts-mode = "0.5"
 
 # Used in benches and tests.
 criterion = { version = "0.5", optional = true }
-futures = { version = "0.3", optional = true }
 rand = { version = "0.9.0", optional = true }
 rand_distr = { version = "0.5.1", optional = true }
 tokio = { version = "1.44", features = ["rt-multi-thread"], optional = true }
@@ -57,7 +56,6 @@ tokio-postgres = { version = "0.7.9", optional = true, features = [
 
 
 [dev-dependencies]
-futures = { version = "0.3" }
 tokio = { version = "1.44", features = ["macros", "rt-multi-thread"] }
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rust-mem = []
 redis-mem = ["redis"]
 sqlite-mem = ["async-sqlite"]
 test-utils = ["criterion", "rand", "rand_distr", "agnostic/tokio"]
-postgres-mem = ["tokio-postgres", "deadpool-postgres"]
+postgres-mem = ["agnostic/tokio", "tokio-postgres", "deadpool-postgres"]
 
 [dependencies]
 aes = "0.8"
@@ -35,7 +35,7 @@ cosmian_crypto_core = { version = "10.1", default-features = false, features = [
 ] }
 xts-mode = "0.5"
 
-# Used only in benches and tests
+# Used in benches and tests.
 criterion = { version = "0.6", optional = true }
 rand = { version = "0.9.0", optional = true }
 rand_distr = { version = "0.5.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/lib.rs"
 rust-mem = []
 redis-mem = ["redis"]
 sqlite-mem = ["async-sqlite"]
-test-utils = ["tokio", "criterion", "rand", "rand_distr"]
+test-utils = ["criterion", "rand", "rand_distr"]
 postgres-mem = ["tokio-postgres", "tokio", "deadpool-postgres"]
 
 [dependencies]
@@ -35,12 +35,10 @@ cosmian_crypto_core = { version = "10.1", default-features = false, features = [
 ] }
 xts-mode = "0.5"
 
-# Used in benches and tests.
+# Used only in benches and tests
 criterion = { version = "0.6", optional = true }
 rand = { version = "0.9.0", optional = true }
 rand_distr = { version = "0.5.1", optional = true }
-tokio = { version = "1.44", features = ["rt-multi-thread"], optional = true }
-
 
 # Memory dependencies
 async-sqlite = { version = "0.5", optional = true }
@@ -50,9 +48,10 @@ redis = { version = "0.28", features = [
     "connection-manager",
     "tokio-comp",
 ], optional = true }
-tokio-postgres = { version = "0.7.9", optional = true, features = [
+tokio = { version = "1.44", features = ["rt-multi-thread"], optional = true }
+tokio-postgres = { version = "0.7.9", features = [
     "array-impls",
-] }
+], optional = true }
 
 
 [dev-dependencies]

--- a/examples/insert.rs
+++ b/examples/insert.rs
@@ -120,11 +120,11 @@ async fn main() {
     }
     // In order to verify insertion was correctly performed, we search for all
     // the indexed keywords...
-    let res = index
-        .keys()
-        .cloned()
-        .map(|kw| (kw, findex.search(&kw).await.expect("search failed")))
-        .collect::<HashMap<_, _>>();
+    let mut res = HashMap::new();
+    for kw in index.keys().cloned() {
+        let values = findex.search(&kw).await.expect("search failed");
+        res.insert(kw, values);
+    }
 
     // ... and verify we get the whole index back!
     assert_eq!(res, index);

--- a/src/adt.rs
+++ b/src/adt.rs
@@ -85,7 +85,6 @@ pub mod tests {
         //! This module defines tests any implementation of the VectorADT interface must pass.
 
         use crate::adt::VectorADT;
-        use futures::{executor::block_on, future::join_all};
 
         /// Adding information from different copies of the same vector should be visible by all
         /// copies.
@@ -127,10 +126,10 @@ pub mod tests {
                     })
                 })
                 .collect::<Vec<_>>();
-            for h in join_all(handles).await {
-                h.unwrap();
+            for h in handles {
+                h.await.unwrap();
             }
-            let mut res = block_on(v.read()).unwrap();
+            let mut res = v.read().await.unwrap();
             let old = res.clone();
             res.sort();
             assert_ne!(old, res);

--- a/src/adt.rs
+++ b/src/adt.rs
@@ -127,7 +127,8 @@ pub mod tests {
                 })
                 .collect::<Vec<_>>();
             for h in handles {
-                h.await.unwrap();
+                h.await
+                    .expect("Join handle failed during test_vector_concurrent");
             }
             let mut res = v.read().await.unwrap();
             let old = res.clone();

--- a/src/findex.rs
+++ b/src/findex.rs
@@ -141,11 +141,10 @@ mod tests {
         memory::MemoryEncryptionLayer,
     };
     use cosmian_crypto_core::{CsRng, Secret, define_byte_type, reexport::rand_core::SeedableRng};
-    use futures::executor::block_on;
     use std::collections::HashSet;
 
-    #[test]
-    fn test_insert_search_delete_search() {
+    #[tokio::test]
+    async fn test_insert_search_delete_search() {
         // Define a byte type, and use `Value` as an alias for 8-bytes values of
         // that type.
         type Value = Bytes<8>;
@@ -178,10 +177,16 @@ mod tests {
             Value::try_from(2).unwrap(),
             Value::try_from(4).unwrap(),
         ];
-        block_on(findex.insert("cat".to_string(), cat_bindings.clone())).unwrap();
-        block_on(findex.insert("dog".to_string(), dog_bindings.clone())).unwrap();
-        let cat_res = block_on(findex.search(&"cat".to_string())).unwrap();
-        let dog_res = block_on(findex.search(&"dog".to_string())).unwrap();
+        findex
+            .insert("cat".to_string(), cat_bindings.clone())
+            .await
+            .unwrap();
+        findex
+            .insert("dog".to_string(), dog_bindings.clone())
+            .await
+            .unwrap();
+        let cat_res = findex.search(&"cat".to_string()).await.unwrap();
+        let dog_res = findex.search(&"dog".to_string()).await.unwrap();
         assert_eq!(
             cat_bindings.iter().cloned().collect::<HashSet<_>>(),
             cat_res
@@ -191,10 +196,10 @@ mod tests {
             dog_res
         );
 
-        block_on(findex.delete("dog", dog_bindings)).unwrap();
-        block_on(findex.delete("cat", cat_bindings)).unwrap();
-        let cat_res = block_on(findex.search(&"cat".to_string())).unwrap();
-        let dog_res = block_on(findex.search(&"dog".to_string())).unwrap();
+        findex.delete("dog", dog_bindings).await.unwrap();
+        findex.delete("cat", cat_bindings).await.unwrap();
+        let cat_res = findex.search(&"cat".to_string()).await.unwrap();
+        let dog_res = findex.search(&"dog".to_string()).await.unwrap();
         assert_eq!(HashSet::new(), cat_res);
         assert_eq!(HashSet::new(), dog_res);
     }

--- a/src/memory/encryption_layer.rs
+++ b/src/memory/encryption_layer.rs
@@ -142,7 +142,8 @@ mod tests {
         address::Address,
         memory::{MemoryEncryptionLayer, in_memory_store::InMemory},
         test_utils::{
-            gen_seed, test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard,
+            TokioSpawner, gen_seed, test_guarded_write_concurrent, test_single_write_and_read,
+            test_wrong_guard,
         },
     };
 
@@ -184,6 +185,7 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_read_write() {
         let mem = create_memory(&mut CsRng::from_entropy());
-        test_guarded_write_concurrent::<WORD_LENGTH, _>(&mem, gen_seed(), None).await;
+        test_guarded_write_concurrent::<WORD_LENGTH, _, _>(&mem, gen_seed(), None, &TokioSpawner)
+            .await;
     }
 }

--- a/src/memory/encryption_layer.rs
+++ b/src/memory/encryption_layer.rs
@@ -185,7 +185,6 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_read_write() {
         let mem = create_memory(&mut CsRng::from_entropy());
-        test_guarded_write_concurrent::<WORD_LENGTH, _, _>(&mem, gen_seed(), None, &TokioSpawner)
-            .await;
+        test_guarded_write_concurrent::<WORD_LENGTH, _, TokioSpawner>(&mem, gen_seed(), None).await;
     }
 }

--- a/src/memory/in_memory_store.rs
+++ b/src/memory/in_memory_store.rs
@@ -95,28 +95,29 @@ mod tests {
 
     use super::InMemory;
     use crate::{
-        test_utils::gen_seed,
+        ADDRESS_LENGTH, WORD_LENGTH,
         test_utils::{
-            TokioSpawner, test_guarded_write_concurrent, test_single_write_and_read,
+            TokioSpawner, gen_seed, test_guarded_write_concurrent, test_single_write_and_read,
             test_wrong_guard,
         },
     };
 
     #[tokio::test]
     async fn test_sequential_read_write() {
-        let memory = InMemory::<[u8; 16], [u8; 16]>::default();
+        let memory = InMemory::<[u8; ADDRESS_LENGTH], [u8; WORD_LENGTH]>::default();
         test_single_write_and_read(&memory, gen_seed()).await;
     }
 
     #[tokio::test]
     async fn test_sequential_wrong_guard() {
-        let memory = InMemory::<[u8; 16], [u8; 16]>::default();
+        let memory = InMemory::<[u8; ADDRESS_LENGTH], [u8; WORD_LENGTH]>::default();
         test_wrong_guard(&memory, gen_seed()).await;
     }
 
     #[tokio::test]
     async fn test_concurrent_read_write() {
-        let memory = InMemory::<[u8; 16], [u8; 16]>::default();
-        test_guarded_write_concurrent(&memory, gen_seed(), None, &TokioSpawner).await;
+        let memory = InMemory::<[u8; ADDRESS_LENGTH], [u8; WORD_LENGTH]>::default();
+        test_guarded_write_concurrent::<WORD_LENGTH, _, TokioSpawner>(&memory, gen_seed(), None)
+            .await;
     }
 }

--- a/src/memory/in_memory_store.rs
+++ b/src/memory/in_memory_store.rs
@@ -96,7 +96,10 @@ mod tests {
     use super::InMemory;
     use crate::{
         test_utils::gen_seed,
-        test_utils::{test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard},
+        test_utils::{
+            TokioSpawner, test_guarded_write_concurrent, test_single_write_and_read,
+            test_wrong_guard,
+        },
     };
 
     #[tokio::test]
@@ -114,6 +117,6 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_read_write() {
         let memory = InMemory::<[u8; 16], [u8; 16]>::default();
-        test_guarded_write_concurrent(&memory, gen_seed(), None).await;
+        test_guarded_write_concurrent(&memory, gen_seed(), None, &TokioSpawner).await;
     }
 }

--- a/src/memory/in_memory_store.rs
+++ b/src/memory/in_memory_store.rs
@@ -97,8 +97,7 @@ mod tests {
     use crate::{
         ADDRESS_LENGTH, WORD_LENGTH,
         test_utils::{
-            TokioSpawner, gen_seed, test_guarded_write_concurrent, test_single_write_and_read,
-            test_wrong_guard,
+            gen_seed, test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard,
         },
     };
 
@@ -115,9 +114,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_concurrent_read_write() {
+    async fn test_concurrent_read_write_tokio() {
         let memory = InMemory::<[u8; ADDRESS_LENGTH], [u8; WORD_LENGTH]>::default();
-        test_guarded_write_concurrent::<WORD_LENGTH, _, TokioSpawner>(&memory, gen_seed(), None)
-            .await;
+        test_guarded_write_concurrent::<WORD_LENGTH, _, agnostic::tokio::TokioSpawner>(
+            &memory,
+            gen_seed(),
+            None,
+        )
+        .await;
     }
 }

--- a/src/memory/postgresql_store/memory.rs
+++ b/src/memory/postgresql_store/memory.rs
@@ -242,7 +242,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        ADDRESS_LENGTH, Address, WORD_LENGTH,
+        ADDRESS_LENGTH, Address, TokioSpawner, WORD_LENGTH,
         test_utils::{
             gen_seed, test_guarded_write_concurrent, test_rw_same_address,
             test_single_write_and_read, test_wrong_guard,
@@ -354,7 +354,13 @@ mod tests {
     #[tokio::test]
     async fn test_rw_ccr() -> Result<(), PostgresMemoryError> {
         setup_and_run_test("findex_test_rw_ccr", |m| async move {
-            test_guarded_write_concurrent::<WORD_LENGTH, _>(&m, gen_seed(), Some(100)).await;
+            test_guarded_write_concurrent::<WORD_LENGTH, _, _>(
+                &m,
+                gen_seed(),
+                Some(100),
+                &TokioSpawner,
+            )
+            .await;
         })
         .await
     }

--- a/src/memory/postgresql_store/memory.rs
+++ b/src/memory/postgresql_store/memory.rs
@@ -354,11 +354,10 @@ mod tests {
     #[tokio::test]
     async fn test_rw_ccr() -> Result<(), PostgresMemoryError> {
         setup_and_run_test("findex_test_rw_ccr", |m| async move {
-            test_guarded_write_concurrent::<WORD_LENGTH, _, _>(
+            test_guarded_write_concurrent::<WORD_LENGTH, _, TokioSpawner>(
                 &m,
                 gen_seed(),
                 Some(100),
-                &TokioSpawner,
             )
             .await;
         })

--- a/src/memory/redis_store.rs
+++ b/src/memory/redis_store.rs
@@ -149,8 +149,8 @@ mod tests {
         WORD_LENGTH,
         test_utils::gen_seed,
         {
-            test_guarded_write_concurrent, test_rw_same_address, test_single_write_and_read,
-            test_wrong_guard,
+            TokioSpawner, test_guarded_write_concurrent, test_rw_same_address,
+            test_single_write_and_read, test_wrong_guard,
         },
     };
 
@@ -182,6 +182,7 @@ mod tests {
     #[tokio::test]
     async fn test_rw_ccr() {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_guarded_write_concurrent::<WORD_LENGTH, _>(&m, gen_seed(), None).await
+        test_guarded_write_concurrent::<WORD_LENGTH, _, _>(&m, gen_seed(), None, &TokioSpawner)
+            .await
     }
 }

--- a/src/memory/redis_store.rs
+++ b/src/memory/redis_store.rs
@@ -182,7 +182,6 @@ mod tests {
     #[tokio::test]
     async fn test_rw_ccr() {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_guarded_write_concurrent::<WORD_LENGTH, _, _>(&m, gen_seed(), None, &TokioSpawner)
-            .await
+        test_guarded_write_concurrent::<WORD_LENGTH, _, TokioSpawner>(&m, gen_seed(), None).await
     }
 }

--- a/src/memory/redis_store.rs
+++ b/src/memory/redis_store.rs
@@ -149,8 +149,8 @@ mod tests {
         WORD_LENGTH,
         test_utils::gen_seed,
         {
-            TokioSpawner, test_guarded_write_concurrent, test_rw_same_address,
-            test_single_write_and_read, test_wrong_guard,
+            test_guarded_write_concurrent, test_rw_same_address, test_single_write_and_read,
+            test_wrong_guard,
         },
     };
 
@@ -182,6 +182,11 @@ mod tests {
     #[tokio::test]
     async fn test_rw_ccr() {
         let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_guarded_write_concurrent::<WORD_LENGTH, _, TokioSpawner>(&m, gen_seed(), None).await
+        test_guarded_write_concurrent::<WORD_LENGTH, _, agnostic::tokio::TokioSpawner>(
+            &m,
+            gen_seed(),
+            None,
+        )
+        .await
     }
 }

--- a/src/memory/sqlite_store.rs
+++ b/src/memory/sqlite_store.rs
@@ -176,7 +176,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        WORD_LENGTH, gen_seed, test_guarded_write_concurrent, test_rw_same_address,
+        TokioSpawner, WORD_LENGTH, gen_seed, test_guarded_write_concurrent, test_rw_same_address,
         test_single_write_and_read, test_wrong_guard,
     };
 
@@ -211,6 +211,6 @@ mod tests {
         let m = SqliteMemory::<_, [u8; WORD_LENGTH]>::connect(DB_PATH)
             .await
             .unwrap();
-        test_guarded_write_concurrent(&m, gen_seed(), Some(100)).await
+        test_guarded_write_concurrent(&m, gen_seed(), Some(100), &TokioSpawner).await
     }
 }

--- a/src/memory/sqlite_store.rs
+++ b/src/memory/sqlite_store.rs
@@ -211,6 +211,7 @@ mod tests {
         let m = SqliteMemory::<_, [u8; WORD_LENGTH]>::connect(DB_PATH)
             .await
             .unwrap();
-        test_guarded_write_concurrent(&m, gen_seed(), Some(100), &TokioSpawner).await
+        test_guarded_write_concurrent::<WORD_LENGTH, _, TokioSpawner>(&m, gen_seed(), Some(100))
+            .await
     }
 }

--- a/src/memory/sqlite_store.rs
+++ b/src/memory/sqlite_store.rs
@@ -176,7 +176,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        TokioSpawner, WORD_LENGTH, gen_seed, test_guarded_write_concurrent, test_rw_same_address,
+        WORD_LENGTH, gen_seed, test_guarded_write_concurrent, test_rw_same_address,
         test_single_write_and_read, test_wrong_guard,
     };
 
@@ -211,7 +211,11 @@ mod tests {
         let m = SqliteMemory::<_, [u8; WORD_LENGTH]>::connect(DB_PATH)
             .await
             .unwrap();
-        test_guarded_write_concurrent::<WORD_LENGTH, _, TokioSpawner>(&m, gen_seed(), Some(100))
-            .await
+        test_guarded_write_concurrent::<WORD_LENGTH, _, agnostic::tokio::TokioSpawner>(
+            &m,
+            gen_seed(),
+            Some(100),
+        )
+        .await
     }
 }

--- a/src/test_utils/benches.rs
+++ b/src/test_utils/benches.rs
@@ -138,7 +138,9 @@ pub fn bench_memory_search_multiple_keywords<
                             }))
                         }
                         for res in handles {
-                            res.await.expect("Search task failed").unwrap();
+                            res.await
+                                .expect("Join failure during search operation")
+                                .expect("Search task failed");
                         }
                     })
                 },
@@ -191,7 +193,7 @@ pub fn bench_memory_insert_multiple_bindings<
                     TokioRuntime::block_on(clear(&mut m)).unwrap();
                     (kw, vs.clone())
                 },
-                |(kw, vs)| TokioRuntime::block_on(findex.insert(kw, vs)).expect("search failed"),
+                |(kw, vs)| TokioRuntime::block_on(findex.insert(kw, vs)).expect("Search failed"),
                 criterion::BatchSize::SmallInput,
             );
         });
@@ -258,7 +260,9 @@ pub fn bench_memory_contention<
                                 })
                                 .collect::<Vec<_>>();
                             for h in handles {
-                                h.await.expect("Insert task failed").unwrap();
+                                h.await
+                                    .expect("Join handle failed during insert.")
+                                    .expect("Insert task failed");
                             }
                         })
                     },
@@ -300,7 +304,9 @@ pub fn bench_memory_contention<
                                 handles.push(h);
                             }
                             for h in handles {
-                                h.await.expect("Insert task failed").unwrap();
+                                h.await
+                                    .expect("Join handle failed during insert.")
+                                    .expect("Insert task failed");
                             }
                         })
                     },

--- a/src/test_utils/benches.rs
+++ b/src/test_utils/benches.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use cosmian_crypto_core::{Secret, reexport::rand_core::CryptoRngCore};
 use criterion::{BenchmarkId, Criterion};
-use futures::future::join_all;
 use std::{collections::HashSet, fmt::Debug, sync::Arc};
 use tokio::runtime::{Builder, Runtime};
 

--- a/src/test_utils/benches.rs
+++ b/src/test_utils/benches.rs
@@ -1,3 +1,6 @@
+//! This module provides a comprehensive benchmarking suite for testing the performance of Findex memory implementations.
+//! These benchmarks are designed to be generic and work with any memory backend that implements the MemoryADT trait.
+//! The [findex-memories](https://github.com/Cosmian/findex-memories) crate provides a set of memory backends that have been benched.
 use crate::{
     ADDRESS_LENGTH, Address, Findex, IndexADT, MemoryADT, MemoryEncryptionLayer, WORD_LENGTH,
     dummy_decode, dummy_encode,

--- a/src/test_utils/benches.rs
+++ b/src/test_utils/benches.rs
@@ -261,7 +261,7 @@ pub fn bench_memory_contention<
                                 })
                                 .collect::<Vec<_>>();
                             for h in handles {
-                                h.await.expect("Insert task failed");
+                                h.await.expect("Insert task failed").unwrap();
                             }
                         })
                     },

--- a/src/test_utils/memory_tests.rs
+++ b/src/test_utils/memory_tests.rs
@@ -223,7 +223,7 @@ pub trait TaskSpawner: Send + Sync {
     type JoinHandle<T: Send + 'static>: Future<Output = Result<T, Self::JoinError>> + Send;
     type JoinError: std::error::Error + Send;
 
-    fn spawn<F>(&self, future: F) -> Self::JoinHandle<F::Output>
+    fn spawn<F>(future: F) -> Self::JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static;
@@ -235,7 +235,7 @@ impl TaskSpawner for TokioSpawner {
     type JoinHandle<T: Send + 'static> = tokio::task::JoinHandle<T>;
     type JoinError = tokio::task::JoinError;
 
-    fn spawn<F>(&self, future: F) -> Self::JoinHandle<F::Output>
+    fn spawn<F>(future: F) -> Self::JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
@@ -260,7 +260,6 @@ pub async fn test_guarded_write_concurrent<const WORD_LENGTH: usize, Memory, S>(
     memory: &Memory,
     seed: [u8; SEED_LENGTH],
     n_threads: Option<usize>,
-    spawer: &S,
 ) where
     Memory: 'static + Send + Sync + MemoryADT + Clone,
     Memory::Address: Send + From<[u8; ADDRESS_LENGTH]>,
@@ -318,7 +317,7 @@ pub async fn test_guarded_write_concurrent<const WORD_LENGTH: usize, Memory, S>(
     let handles = (0..n)
         .map(|_| {
             let m = memory.clone();
-            spawer.spawn(worker(m, a))
+            S::spawn(worker(m, a))
         })
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
This is a preparatory pr for : https://github.com/Cosmian/findex/pull/138

It was cut aside because it is subject to debate and we can omit it if there is a valid motivation to keep **futures**

## Motivation : 
- Reduce dependencies by deleting futures crate from dependency list without impacting any functionnality
- Do exactly what the futures crate used to do without adding more deps

## Reasons why : 
-[ Tokio re-exports what it needs from the futures crate](https://users.rust-lang.org/t/relationship-between-std-futures-futures-and-tokio/38077), so (in general) we don't need both
- **block_on** blocks the whole thread and prevents the runtime from optimising the ressources
- Long quest of having the less dependencies for the findex repository