### PR TITLE
feat: Findex as a runtime agnostic library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ readme = "README.md"
 
 
 [workspace.dependencies]
-agnostic-lite = { version = "0.5.6" }
+agnostic-lite = { version = ">=0.5.6" }
 cosmian_crypto_core = { version = "10.2", default-features = false, features = [
     "macro",
     "sha3",
 ] }
 criterion = { version = "0.6" }
-smol-macros = { version = "0.1.1" }
+smol-macros = { version = "0.1" }
 tokio = { version = "1.46" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,5 @@ cosmian_crypto_core = { version = "10.1", default-features = false, features = [
 ] }
 criterion = { version = "0.6" }
 tokio = { version = "1.46" }
+agnostic-lite = { version = "0.5.6" }
+smol-macros = { version = "0.1.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ readme = "README.md"
 
 
 [workspace.dependencies]
-cosmian_crypto_core = { version = "10.1", default-features = false, features = [
+agnostic-lite = { version = "0.5.6" }
+cosmian_crypto_core = { version = "10.2", default-features = false, features = [
     "macro",
     "sha3",
 ] }
 criterion = { version = "0.6" }
-tokio = { version = "1.46" }
-agnostic-lite = { version = "0.5.6" }
 smol-macros = { version = "0.1.1" }
+tokio = { version = "1.46" }

--- a/crate/findex/Cargo.toml
+++ b/crate/findex/Cargo.toml
@@ -15,10 +15,10 @@ name = "cosmian_findex"
 path = "src/lib.rs"
 
 [features]
-test-utils = ["tokio", "criterion"]
 redis-mem = ["cosmian_memories/redis-mem"]
 sqlite-mem = ["cosmian_memories/sqlite-mem"]
 postgres-mem = ["cosmian_memories/postgres-mem"]
+test-utils = ["agnostic-lite", "criterion"]
 
 [dependencies]
 aes = "0.8"
@@ -27,11 +27,17 @@ cosmian_memories = { path = "../memories", version = "8.0" }
 xts-mode = "0.5"
 
 # Optional dependencies for testing and benchmarking.
-tokio = { workspace = true, optional = true }
 criterion = { workspace = true, optional = true }
+agnostic-lite = { version = "0.5.6", optional = true, features = [
+    "tokio",
+    "smol",
+    "wasm",
+] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+agnostic-lite = { version = "0.5.6", features = ["tokio", "smol", "wasm"] }
+tokio = { version = "1.44", features = ["macros", "rt-multi-thread"] }
+smol-macros = "0.1.1"
 cosmian_memories = { path = "../memories", version = "8.0", features = [
     "redis-mem",
     "sqlite-mem",

--- a/crate/findex/Cargo.toml
+++ b/crate/findex/Cargo.toml
@@ -28,16 +28,16 @@ xts-mode = "0.5"
 
 # Optional dependencies for testing and benchmarking.
 criterion = { workspace = true, optional = true }
-agnostic-lite = { version = "0.5.6", optional = true, features = [
+agnostic-lite = { workspace = true, optional = true, features = [
     "tokio",
     "smol",
     "wasm",
-] }
+] } # TODO: delete this later
 
 [dev-dependencies]
-agnostic-lite = { version = "0.5.6", features = ["tokio", "smol", "wasm"] }
+agnostic-lite = { workspace = true, features = ["tokio", "smol", "wasm"] }
 tokio = { version = "1.44", features = ["macros", "rt-multi-thread"] }
-smol-macros = "0.1.1"
+smol-macros = { workspace = true }
 cosmian_memories = { path = "../memories", version = "8.0", features = [
     "redis-mem",
     "sqlite-mem",

--- a/crate/findex/Cargo.toml
+++ b/crate/findex/Cargo.toml
@@ -27,17 +27,15 @@ cosmian_memories = { path = "../memories", version = "8.0" }
 xts-mode = "0.5"
 
 # Optional dependencies for testing and benchmarking.
-criterion = { workspace = true, optional = true }
 agnostic-lite = { workspace = true, optional = true, features = [
     "tokio",
     "smol",
     "wasm",
-] } # TODO: delete this later
+] }
+criterion = { workspace = true, optional = true }
 
 [dev-dependencies]
-agnostic-lite = { workspace = true, features = ["tokio", "smol", "wasm"] }
-tokio = { version = "1.44", features = ["macros", "rt-multi-thread"] }
-smol-macros = { workspace = true }
+agnostic-lite = { workspace = true }
 cosmian_memories = { path = "../memories", version = "8.0", features = [
     "redis-mem",
     "sqlite-mem",
@@ -46,6 +44,8 @@ cosmian_memories = { path = "../memories", version = "8.0", features = [
 ] }
 rand = "0.9"
 rand_distr = "0.5"
+smol-macros = { workspace = true }
+tokio = { version = "1.44", features = ["macros", "rt-multi-thread"] }
 
 [[example]]
 name = "in_memory"

--- a/crate/findex/Cargo.toml
+++ b/crate/findex/Cargo.toml
@@ -35,7 +35,7 @@ agnostic-lite = { workspace = true, optional = true, features = [
 criterion = { workspace = true, optional = true }
 
 [dev-dependencies]
-agnostic-lite = { workspace = true }
+agnostic-lite = { workspace = true, features = ["tokio"] }
 cosmian_memories = { path = "../memories", version = "8.0", features = [
     "redis-mem",
     "sqlite-mem",

--- a/crate/findex/benches/benches.rs
+++ b/crate/findex/benches/benches.rs
@@ -6,10 +6,10 @@ use cosmian_crypto_core::{
     CsRng,
     reexport::rand_core::{RngCore, SeedableRng},
 };
-use cosmian_findex::WORD_LENGTH;
 use cosmian_findex::{
-    bench_memory_contention, bench_memory_insert_multiple_bindings, bench_memory_one_to_many,
-    bench_memory_search_multiple_bindings, bench_memory_search_multiple_keywords,
+    WORD_LENGTH, bench_memory_contention, bench_memory_insert_multiple_bindings,
+    bench_memory_one_to_many, bench_memory_search_multiple_bindings,
+    bench_memory_search_multiple_keywords, reexport::tokio::TokioRuntime,
 };
 use cosmian_memories::InMemory;
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -70,13 +70,12 @@ async fn connect_and_init_table(
 }
 // Number of points in each graph.
 const N_PTS: usize = 9;
-
 fn bench_search_multiple_bindings(c: &mut Criterion) {
     let mut rng = CsRng::from_entropy();
-    let rt = Runtime::new().expect("Failed to create Tokio runtime");
+    let rt = Builder::new_multi_thread().enable_all().build().unwrap();
     let _guard = rt.enter();
 
-    bench_memory_search_multiple_bindings::<_, cosmian_findex::reexport::tokio::TokioRuntime>(
+    bench_memory_search_multiple_bindings::<_, TokioRuntime>(
         "in-memory",
         N_PTS,
         async || InMemory::default(),
@@ -85,7 +84,7 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
     );
 
     #[cfg(feature = "redis-mem")]
-    bench_memory_search_multiple_bindings(
+    bench_memory_search_multiple_bindings::<_, TokioRuntime>(
         "Redis",
         N_PTS,
         async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
@@ -94,7 +93,7 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
     );
 
     #[cfg(feature = "sqlite-mem")]
-    bench_memory_search_multiple_bindings(
+    bench_memory_search_multiple_bindings::<_, TokioRuntime>(
         "SQLite",
         N_PTS,
         async || {
@@ -109,7 +108,7 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
     );
 
     #[cfg(feature = "postgres-mem")]
-    bench_memory_search_multiple_bindings(
+    bench_memory_search_multiple_bindings::<_, TokioRuntime>(
         "Postgres",
         N_PTS,
         async || {
@@ -123,13 +122,12 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
         &mut rng,
     );
 }
-
 fn bench_search_multiple_keywords(c: &mut Criterion) {
     let mut rng = CsRng::from_entropy();
-    let rt = Runtime::new().expect("Failed to create Tokio runtime");
+    let rt = Builder::new_multi_thread().enable_all().build().unwrap();
     let _guard = rt.enter();
 
-    bench_memory_search_multiple_keywords::<_, cosmian_findex::reexport::tokio::TokioRuntime>(
+    bench_memory_search_multiple_keywords::<_, TokioRuntime>(
         "in-memory",
         N_PTS,
         async || InMemory::default(),
@@ -138,7 +136,7 @@ fn bench_search_multiple_keywords(c: &mut Criterion) {
     );
 
     #[cfg(feature = "redis-mem")]
-    bench_memory_search_multiple_keywords(
+    bench_memory_search_multiple_keywords::<_, TokioRuntime>(
         "Redis",
         N_PTS,
         async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
@@ -147,7 +145,7 @@ fn bench_search_multiple_keywords(c: &mut Criterion) {
     );
 
     #[cfg(feature = "sqlite-mem")]
-    bench_memory_search_multiple_keywords(
+    bench_memory_search_multiple_keywords::<_, TokioRuntime>(
         "SQLite",
         N_PTS,
         async || {
@@ -162,7 +160,7 @@ fn bench_search_multiple_keywords(c: &mut Criterion) {
     );
 
     #[cfg(feature = "postgres-mem")]
-    bench_memory_search_multiple_keywords(
+    bench_memory_search_multiple_keywords::<_, TokioRuntime>(
         "Postgres",
         N_PTS,
         async || {
@@ -174,13 +172,12 @@ fn bench_search_multiple_keywords(c: &mut Criterion) {
         &mut rng,
     );
 }
-
 fn bench_insert_multiple_bindings(c: &mut Criterion) {
     let mut rng = CsRng::from_entropy();
-    let rt = Runtime::new().expect("Failed to create Tokio runtime");
+    let rt = Builder::new_multi_thread().enable_all().build().unwrap();
     let _guard = rt.enter();
 
-    bench_memory_insert_multiple_bindings::<_, _, cosmian_findex::reexport::tokio::TokioRuntime>(
+    bench_memory_insert_multiple_bindings::<_, _, TokioRuntime>(
         "in-memory",
         N_PTS,
         async || InMemory::default(),
@@ -193,7 +190,7 @@ fn bench_insert_multiple_bindings(c: &mut Criterion) {
     );
 
     #[cfg(feature = "redis-mem")]
-    bench_memory_insert_multiple_bindings(
+    bench_memory_insert_multiple_bindings::<_, _, TokioRuntime>(
         "Redis",
         N_PTS,
         async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
@@ -203,7 +200,7 @@ fn bench_insert_multiple_bindings(c: &mut Criterion) {
     );
 
     #[cfg(feature = "sqlite-mem")]
-    bench_memory_insert_multiple_bindings(
+    bench_memory_insert_multiple_bindings::<_, _, TokioRuntime>(
         "SQLite",
         N_PTS,
         async || {
@@ -219,7 +216,7 @@ fn bench_insert_multiple_bindings(c: &mut Criterion) {
     );
 
     #[cfg(feature = "postgres-mem")]
-    bench_memory_insert_multiple_bindings(
+    bench_memory_insert_multiple_bindings::<_, _, TokioRuntime>(
         "Postgres",
         N_PTS,
         async || {
@@ -240,7 +237,7 @@ fn bench_contention(c: &mut Criterion) {
     let rt = Builder::new_multi_thread().enable_all().build().unwrap();
     let _guard = rt.enter();
 
-    bench_memory_contention::<_, _, cosmian_findex::reexport::tokio::TokioRuntime>(
+    bench_memory_contention::<_, _, TokioRuntime>(
         "in-memory",
         N_PTS,
         async || InMemory::default(),
@@ -253,7 +250,7 @@ fn bench_contention(c: &mut Criterion) {
     );
 
     #[cfg(feature = "redis-mem")]
-    bench_memory_contention(
+    bench_memory_contention::<_, _, TokioRuntime>(
         "Redis",
         N_PTS,
         async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
@@ -263,7 +260,7 @@ fn bench_contention(c: &mut Criterion) {
     );
 
     #[cfg(feature = "sqlite-mem")]
-    bench_memory_contention(
+    bench_memory_contention::<_, _, TokioRuntime>(
         "SQLite",
         N_PTS,
         async || {
@@ -279,7 +276,7 @@ fn bench_contention(c: &mut Criterion) {
     );
 
     #[cfg(feature = "postgres-mem")]
-    bench_memory_contention(
+    bench_memory_contention::<_, _, TokioRuntime>(
         "Postgres",
         N_PTS,
         async || {
@@ -374,18 +371,19 @@ mod delayed_memory {
     }
 }
 
+#[cfg(any(feature = "redis-mem", feature = "postgres-mem"))]
 fn bench_one_to_many(c: &mut Criterion) {
-    #[cfg(feature = "redis-mem")]
+    use delayed_memory::DelayedMemory;
+
     let mut rng = CsRng::from_entropy();
-
-    #[cfg(any(feature = "redis-mem", feature = "postgres-mem"))]
-    use delayed_memory::*;
-
     let delay_params = [(1, 1), (10, 1), (10, 5)]; // tuples of (mean, variance)
+
+    let rt = Builder::new_multi_thread().enable_all().build().unwrap();
+    let _guard = rt.enter();
 
     #[cfg(feature = "redis-mem")]
     for (mean, variance) in &delay_params {
-        bench_memory_one_to_many(
+        bench_memory_one_to_many::<_, _, TokioRuntime>(
             "Redis",
             N_PTS,
             async || {
@@ -403,7 +401,7 @@ fn bench_one_to_many(c: &mut Criterion) {
 
     #[cfg(feature = "postgres-mem")]
     for (mean, variance) in &delay_params {
-        bench_memory_one_to_many(
+        bench_memory_one_to_many::<_, _, TokioRuntime>(
             "Postgres",
             N_PTS,
             async || {

--- a/crate/findex/benches/benches.rs
+++ b/crate/findex/benches/benches.rs
@@ -13,6 +13,7 @@ use cosmian_findex::{
 };
 use cosmian_memories::InMemory;
 use criterion::{Criterion, criterion_group, criterion_main};
+use tokio::runtime::{Builder, Runtime};
 
 #[cfg(feature = "sqlite-mem")]
 use cosmian_memories::SqliteMemory;
@@ -72,8 +73,10 @@ const N_PTS: usize = 9;
 
 fn bench_search_multiple_bindings(c: &mut Criterion) {
     let mut rng = CsRng::from_entropy();
+    let rt = Runtime::new().expect("Failed to create Tokio runtime");
+    let _guard = rt.enter();
 
-    bench_memory_search_multiple_bindings(
+    bench_memory_search_multiple_bindings::<_, cosmian_findex::reexport::tokio::TokioRuntime>(
         "in-memory",
         N_PTS,
         async || InMemory::default(),
@@ -123,8 +126,10 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
 
 fn bench_search_multiple_keywords(c: &mut Criterion) {
     let mut rng = CsRng::from_entropy();
+    let rt = Runtime::new().expect("Failed to create Tokio runtime");
+    let _guard = rt.enter();
 
-    bench_memory_search_multiple_keywords(
+    bench_memory_search_multiple_keywords::<_, cosmian_findex::reexport::tokio::TokioRuntime>(
         "in-memory",
         N_PTS,
         async || InMemory::default(),
@@ -172,8 +177,10 @@ fn bench_search_multiple_keywords(c: &mut Criterion) {
 
 fn bench_insert_multiple_bindings(c: &mut Criterion) {
     let mut rng = CsRng::from_entropy();
+    let rt = Runtime::new().expect("Failed to create Tokio runtime");
+    let _guard = rt.enter();
 
-    bench_memory_insert_multiple_bindings(
+    bench_memory_insert_multiple_bindings::<_, _, cosmian_findex::reexport::tokio::TokioRuntime>(
         "in-memory",
         N_PTS,
         async || InMemory::default(),
@@ -230,8 +237,10 @@ fn bench_insert_multiple_bindings(c: &mut Criterion) {
 
 fn bench_contention(c: &mut Criterion) {
     let mut rng = CsRng::from_entropy();
+    let rt = Builder::new_multi_thread().enable_all().build().unwrap();
+    let _guard = rt.enter();
 
-    bench_memory_contention(
+    bench_memory_contention::<_, _, cosmian_findex::reexport::tokio::TokioRuntime>(
         "in-memory",
         N_PTS,
         async || InMemory::default(),

--- a/crate/findex/src/benches.rs
+++ b/crate/findex/src/benches.rs
@@ -3,10 +3,7 @@
 //! to be generic and work with any memory back end that implements the MemoryADT
 //! trait.
 
-use crate::{
-    ADDRESS_LENGTH, Address, Findex, IndexADT, MemoryADT, MemoryEncryptionLayer, WORD_LENGTH,
-    dummy_decode, dummy_encode,
-};
+use crate::{Findex, IndexADT, MemoryEncryptionLayer, WORD_LENGTH, dummy_decode, dummy_encode};
 use agnostic_lite::{JoinHandle, RuntimeLite};
 use cosmian_crypto_core::{Secret, reexport::rand_core::CryptoRngCore};
 use cosmian_memories::{ADDRESS_LENGTH, Address, MemoryADT};

--- a/crate/findex/src/encryption_layer.rs
+++ b/crate/findex/src/encryption_layer.rs
@@ -182,6 +182,11 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_read_write() {
         let mem = create_memory(&mut CsRng::from_entropy());
-        test_guarded_write_concurrent::<WORD_LENGTH, _>(&mem, gen_seed(), None).await;
+        test_guarded_write_concurrent::<16, _, agnostic_lite::tokio::TokioSpawner>(
+            &mem,
+            gen_seed(),
+            None,
+        )
+        .await;
     }
 }

--- a/crate/findex/src/findex.rs
+++ b/crate/findex/src/findex.rs
@@ -220,15 +220,15 @@ mod tests {
             let findex = Findex::new(memory, dummy_encode::<WORD_LENGTH, Value>, dummy_decode);
 
             // Test concurrent inserts to the same keyword
-            let values1 = Arc::new( [
+            let values1 = Arc::new([
                 Value::try_from(1).unwrap(),
                 Value::try_from(2).unwrap(),
             ]);
-            let values2 = Arc::new( [
+            let values2 = Arc::new([
                 Value::try_from(3).unwrap(),
                 Value::try_from(4).unwrap(),
             ]);
-            let values3 =Arc::new(  [
+            let values3 = Arc::new([
                 Value::try_from(5).unwrap(),
                 Value::try_from(6).unwrap(),
             ]);

--- a/crate/findex/src/lib.rs
+++ b/crate/findex/src/lib.rs
@@ -32,3 +32,9 @@ pub use encoding::{
     dummy_encoding::{WORD_LENGTH, dummy_decode, dummy_encode},
     tests::test_encoding,
 };
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod reexport {
+    // Re-exporting the most commonly used runtime interfaces for convenience.
+    pub use agnostic_lite::{smol, tokio, wasm};
+}

--- a/crate/findex/src/lib.rs
+++ b/crate/findex/src/lib.rs
@@ -33,7 +33,7 @@ pub use encoding::{
     tests::test_encoding,
 };
 
-#[cfg(any(test, feature = "test-utils"))]
+#[cfg(feature = "test-utils")]
 pub mod reexport {
     // Re-exporting the most commonly used runtime interfaces for convenience.
     pub use agnostic_lite::{smol, tokio, wasm};

--- a/crate/memories/Cargo.toml
+++ b/crate/memories/Cargo.toml
@@ -35,7 +35,7 @@ tokio-postgres = { version = "0.7", optional = true, features = [
 ] }
 
 [dev-dependencies]
-cosmian_crypto_core.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-smol-macros = { workspace = true }
 agnostic-lite = { workspace = true, features = ["tokio", "smol"] }
+cosmian_crypto_core.workspace = true
+smol-macros = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crate/memories/Cargo.toml
+++ b/crate/memories/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
+<<<<<<< HEAD
 name = "cosmian_memories"
+=======
+name = "cosmian_findex_memories"
+>>>>>>> ba65f62 (feat: start the new branch)
 version.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -34,5 +38,36 @@ tokio-postgres = { version = "0.7", optional = true, features = [
 ] }
 
 [dev-dependencies]
+<<<<<<< HEAD
 cosmian_crypto_core.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+=======
+cosmian_findex = { path = "../findex", version = "8.0", features = [
+    "test-utils",
+] }
+futures = { version = "0.3" } # TODO delete ?
+tokio = { workspace = true, features = [
+    "macros",
+    "rt-multi-thread",
+] } # TODO delete ?
+criterion = { workspace = true }
+rand = { version = "0.9.0" }
+rand_distr = { version = "0.5.1" }
+
+[[bench]]
+name = "benches"
+harness = false
+required-features = ["redis-mem", "sqlite-mem", "postgres-mem", "test-utils"]
+
+[[example]]
+name = "redis"
+required-features = ["redis-mem"]
+
+[[example]]
+name = "sqlite"
+required-features = ["sqlite-mem"]
+
+[[example]]
+name = "postgresql"
+required-features = ["postgres-mem"]
+>>>>>>> ba65f62 (feat: start the new branch)

--- a/crate/memories/Cargo.toml
+++ b/crate/memories/Cargo.toml
@@ -38,3 +38,4 @@ tokio-postgres = { version = "0.7", optional = true, features = [
 cosmian_crypto_core.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 smol-macros = { workspace = true }
+agnostic-lite = { workspace = true, features = ["tokio", "smol"] }

--- a/crate/memories/Cargo.toml
+++ b/crate/memories/Cargo.toml
@@ -1,9 +1,5 @@
 [package]
-<<<<<<< HEAD
 name = "cosmian_memories"
-=======
-name = "cosmian_findex_memories"
->>>>>>> ba65f62 (feat: start the new branch)
 version.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -25,6 +21,7 @@ postgres-mem = ["deadpool-postgres", "tokio", "tokio-postgres"]
 test-utils = ["tokio"]
 
 [dependencies]
+agnostic-lite = { workspace = true }
 async-sqlite = { version = "0.5", optional = true }
 cosmian_crypto_core.workspace = true
 deadpool-postgres = { version = "0.14", optional = true }
@@ -38,36 +35,6 @@ tokio-postgres = { version = "0.7", optional = true, features = [
 ] }
 
 [dev-dependencies]
-<<<<<<< HEAD
 cosmian_crypto_core.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
-=======
-cosmian_findex = { path = "../findex", version = "8.0", features = [
-    "test-utils",
-] }
-futures = { version = "0.3" } # TODO delete ?
-tokio = { workspace = true, features = [
-    "macros",
-    "rt-multi-thread",
-] } # TODO delete ?
-criterion = { workspace = true }
-rand = { version = "0.9.0" }
-rand_distr = { version = "0.5.1" }
-
-[[bench]]
-name = "benches"
-harness = false
-required-features = ["redis-mem", "sqlite-mem", "postgres-mem", "test-utils"]
-
-[[example]]
-name = "redis"
-required-features = ["redis-mem"]
-
-[[example]]
-name = "sqlite"
-required-features = ["sqlite-mem"]
-
-[[example]]
-name = "postgresql"
-required-features = ["postgres-mem"]
->>>>>>> ba65f62 (feat: start the new branch)
+smol-macros = { workspace = true }

--- a/crate/memories/src/databases/postgresql_mem/memory.rs
+++ b/crate/memories/src/databases/postgresql_mem/memory.rs
@@ -315,7 +315,13 @@ mod tests {
     #[tokio::test]
     async fn test_rw_ccr() -> Result<(), PostgresMemoryError> {
         setup_and_run_test("findex_test_rw_ccr", |m| async move {
-            test_guarded_write_concurrent(&m, gen_seed(), Some(100)).await;
+                _,
+            test_guarded_write_concurrent::<
+                _,
+                _,
+                cosmian_findex::reexport::tokio::TokioSpawner,
+            >(&m, gen_seed(), Some(100))
+            .await;
         })
         .await
     }

--- a/crate/memories/src/databases/postgresql_mem/memory.rs
+++ b/crate/memories/src/databases/postgresql_mem/memory.rs
@@ -315,12 +315,11 @@ mod tests {
     #[tokio::test]
     async fn test_rw_ccr() -> Result<(), PostgresMemoryError> {
         setup_and_run_test("findex_test_rw_ccr", |m| async move {
-                _,
-            test_guarded_write_concurrent::<
-                _,
-                _,
-                cosmian_findex::reexport::tokio::TokioSpawner,
-            >(&m, gen_seed(), Some(100))
+            test_guarded_write_concurrent::<129, _, agnostic_lite::tokio::TokioSpawner>(
+                &m,
+                gen_seed(),
+                Some(100),
+            )
             .await;
         })
         .await

--- a/crate/memories/src/databases/redis_mem.rs
+++ b/crate/memories/src/databases/redis_mem.rs
@@ -175,14 +175,15 @@ mod tests {
         test_rw_same_address::<1, _>(&m, gen_seed()).await
     }
 
-    #[tokio::test]
-    async fn test_rw_ccr() {
-        let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-        test_guarded_write_concurrent::<129, _, cosmian_findex::reexport::tokio::TokioSpawner>(
-            &m,
-            gen_seed(),
-            None,
-        )
-        .await
-    }
+    // TODO: fix this
+    // #[tokio::test]
+    // async fn test_rw_ccr() {
+    //     let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
+    //     test_guarded_write_concurrent::<129, _, agnostic_lite::tokio::TokioSpawner>(
+    //         &m,
+    //         gen_seed(),
+    //         None,
+    //     )
+    //     .await
+    // }
 }

--- a/crate/memories/src/databases/redis_mem.rs
+++ b/crate/memories/src/databases/redis_mem.rs
@@ -175,15 +175,14 @@ mod tests {
         test_rw_same_address::<1, _>(&m, gen_seed()).await
     }
 
-    // TODO: fix this
-    // #[tokio::test]
-    // async fn test_rw_ccr() {
-    //     let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
-    //     test_guarded_write_concurrent::<129, _, agnostic_lite::tokio::TokioSpawner>(
-    //         &m,
-    //         gen_seed(),
-    //         None,
-    //     )
-    //     .await
-    // }
+    #[tokio::test]
+    async fn test_rw_ccr() {
+        let m = RedisMemory::new_with_url(&get_redis_url()).await.unwrap();
+        test_guarded_write_concurrent::<129, _, agnostic_lite::tokio::TokioSpawner>(
+            &m,
+            gen_seed(),
+            None,
+        )
+        .await
+    }
 }

--- a/crate/memories/src/databases/redis_mem.rs
+++ b/crate/memories/src/databases/redis_mem.rs
@@ -177,7 +177,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_rw_ccr() {
-        let m = RedisMemory::new_with_url(&get_redis_url()).await.unwrap();
-        test_guarded_write_concurrent::<129, _>(&m, gen_seed(), None).await
+        let m = RedisMemory::connect(&get_redis_url()).await.unwrap();
+        test_guarded_write_concurrent::<129, _, cosmian_findex::reexport::tokio::TokioSpawner>(
+            &m,
+            gen_seed(),
+            None,
+        )
+        .await
     }
 }

--- a/crate/memories/src/databases/sqlite_mem.rs
+++ b/crate/memories/src/databases/sqlite_mem.rs
@@ -245,7 +245,11 @@ mod tests {
         let m = SqliteMemory::<_, [u8; 129]>::new_with_path(DB_PATH, TABLE_NAME.to_owned())
             .await
             .unwrap();
-        m.initialize().await.unwrap();
-        test_guarded_write_concurrent(&m, gen_seed(), Some(100)).await
+        test_guarded_write_concurrent::<
+            WORD_LENGTH,
+            _,
+            cosmian_findex::reexport::tokio::TokioSpawner,
+        >(&m, gen_seed(), Some(100))
+        .await
     }
 }

--- a/crate/memories/src/databases/sqlite_mem.rs
+++ b/crate/memories/src/databases/sqlite_mem.rs
@@ -242,14 +242,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_rw_ccr() {
-        let m = SqliteMemory::<_, [u8; 129]>::new_with_path(DB_PATH, TABLE_NAME.to_owned())
+        let m = SqliteMemory::new_with_path(DB_PATH, TABLE_NAME.to_owned())
             .await
             .unwrap();
-        test_guarded_write_concurrent::<
-            WORD_LENGTH,
-            _,
-            cosmian_findex::reexport::tokio::TokioSpawner,
-        >(&m, gen_seed(), Some(100))
+        test_guarded_write_concurrent::<129, _, agnostic_lite::tokio::TokioSpawner>(
+            &m,
+            gen_seed(),
+            Some(100),
+        )
         .await
     }
 }

--- a/crate/memories/src/in_memory.rs
+++ b/crate/memories/src/in_memory.rs
@@ -123,9 +123,7 @@ mod tests {
         test_rw_same_address(&memory, gen_seed()).await;
     }
 
-    /**
-     * Below, the same asynchronous test is ran using different runtimes.
-     */
+    // Below, the same asynchronous test is ran using different runtimes.
 
     #[tokio::test]
     async fn test_concurrent_read_write_tokio() {

--- a/crate/memories/src/test_utils/memory_tests.rs
+++ b/crate/memories/src/test_utils/memory_tests.rs
@@ -16,8 +16,6 @@ use cosmian_crypto_core::{
 };
 use std::fmt::Debug;
 
-use crate::{ADDRESS_LENGTH, MemoryADT};
-
 pub const SEED_LENGTH: usize = 32;
 
 pub fn gen_seed() -> [u8; SEED_LENGTH] {


### PR DESCRIPTION
This PR seems verbose but the changes are quite minimal, it simply "lets" findex get freed of any tokio/futures constraints, and provides necessary abstractions for users to use any runtime they want 

### Motivation

Using the agnostic-lite crate, I cite : 

> agnostic-lite is an agnostic abstraction layer for any async runtime.

> [...] this crate is not only no_std, but also alloc-free. This means that it can be used in environments where alloc is not available, such as embedded systems. It also has no unsafe code.

The following runtimes are directly builtin into agnostic-lite : 
- tokio
- smol
- wasm-bindgen-futures

And their interfaces were exported through cosmian_findex::reexports. Of course, a client crate is responsible to call its runtime, as its not findex's job anymore.

### ⚠️ Notice !

Agnostic-lite is NOT a runtime, itself. It only provides the necessary abstractions for the code to run on an actual runtime like tokio.

The benches were adapted to run on any abstract runtime, but are ran practically with tokio.

Please not that in case of absence of a running runtime you will get the   "there is no reactor running, must be called from the context of Tokio runtime" error.  You can enter the tokio runtime with : 

```rust
    let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
    let _guard = rt.enter();

    bench_memory_search_multiple_bindings::<_, agnostic_lite::tokio::TokioRuntime>(
       // args
    );

```

### ⚠️ Other modifications

`bench_one_to_many` imports has been slightly refactored