### PR TITLE
Refacto before publication

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -9,5 +9,5 @@ jobs:
     uses: Cosmian/reusable_workflows/.github/workflows/cargo-bench.yml@develop
     with:
       toolchain: 1.87.0
-      features: test-utils,redis-mem,sqlite-mem,rust-mem,postgres-mem
+      features: test-utils,redis-mem,sqlite-mem,postgres-mem
       force: true

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -8,6 +8,6 @@ jobs:
   bench:
     uses: Cosmian/reusable_workflows/.github/workflows/cargo-bench.yml@develop
     with:
-      toolchain: stable
+      toolchain: 1.87.0
       features: test-utils,redis-mem,sqlite-mem,rust-mem,postgres-mem
       force: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
   cargo-lint:
     uses: Cosmian/reusable_workflows/.github/workflows/cargo-nursery.yml@develop
     with:
-      toolchain: 1.85.0
+      toolchain: 1.87.0
       workspace: true
   cargo-machete:
     runs-on: ubuntu-latest
@@ -17,7 +17,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.85.0
+          toolchain: 1.87.0
       - name: Install cargo-machete
         run: cargo install cargo-machete
       - name: Check unused dependencies in findex crate
@@ -34,7 +34,7 @@ jobs:
     uses: Cosmian/reusable_workflows/.github/workflows/cargo-publish.yml@develop
     if: startsWith(github.ref, 'refs/tags/')
     with:
-      toolchain: 1.85.0
+      toolchain: 1.87.0
     secrets: inherit
   cleanup:
     needs:

--- a/.github/workflows/hack.yml
+++ b/.github/workflows/hack.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.87.0
           override: true
       - name: Install cargo-hack
         run: cargo install --locked cargo-hack || true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ cosmian_crypto_core = { version = "10.1", default-features = false, features = [
     "sha3",
 ] }
 criterion = { version = "0.6" }
-tokio = { version = "1.44" }
+tokio = { version = "1.45" }

--- a/crate/findex/src/lib.rs
+++ b/crate/findex/src/lib.rs
@@ -12,6 +12,7 @@ mod error;
 mod findex;
 mod memory;
 mod ovec;
+
 #[cfg(any(test, feature = "test-utils"))]
 mod test_utils;
 

--- a/crate/memories/Cargo.toml
+++ b/crate/memories/Cargo.toml
@@ -17,33 +17,32 @@ path = "src/lib.rs"
 [features]
 redis-mem = ["redis"]
 sqlite-mem = ["async-sqlite"]
-postgres-mem = ["tokio-postgres", "tokio", "deadpool-postgres"]
-test-utils = ["cosmian_findex/test-utils"]
+postgres-mem = ["deadpool-postgres", "tokio", "tokio-postgres"]
+test-utils = ["cosmian_findex/test-utils", "redis/tokio-comp"]
 
 [dependencies]
-cosmian_crypto_core.workspace = true
+async-sqlite = { version = "0.5", optional = true }
 cosmian_findex = { path = "../findex", version = "8.0" }
-async-sqlite = { version = "0.4", optional = true } # `async-sqlite` dependency is pinned at v0.4 due to dependency tree issues with sqlx requiring a lower version of `libsqlite3-sys`
-deadpool-postgres = { version = "0.14.1", optional = true }
+deadpool-postgres = { version = "0.14", optional = true }
 redis = { version = "0.32", default-features = false, features = [
-    "aio",
     "connection-manager",
     "tokio-comp",
 ], optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }
-tokio-postgres = { version = "0.7.9", optional = true, features = [
+tokio-postgres = { version = "0.7", optional = true, features = [
     "array-impls",
 ] }
 
 [dev-dependencies]
+cosmian_crypto_core.workspace = true
 cosmian_findex = { path = "../findex", version = "8.0", features = [
     "test-utils",
 ] }
-futures = { version = "0.3" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 criterion = { workspace = true }
-rand = { version = "0.9.0" }
-rand_distr = { version = "0.5.1" }
+futures = { version = "0.3" }
+rand = "0.9"
+rand_distr = "0.5"
 
 [[bench]]
 name = "benches"

--- a/crate/memories/Cargo.toml
+++ b/crate/memories/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/lib.rs"
 redis-mem = ["redis"]
 sqlite-mem = ["async-sqlite"]
 postgres-mem = ["deadpool-postgres", "tokio", "tokio-postgres"]
-test-utils = ["cosmian_findex/test-utils", "redis/tokio-comp"]
+test-utils = ["cosmian_findex/test-utils"]
 
 [dependencies]
 async-sqlite = { version = "0.5", optional = true }

--- a/crate/memories/benches/benches.rs
+++ b/crate/memories/benches/benches.rs
@@ -81,7 +81,7 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
     bench_memory_search_multiple_bindings(
         "Redis",
         N_PTS,
-        async || RedisMemory::connect(&get_redis_url()).await.unwrap(),
+        async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
         c,
         &mut rng,
     );
@@ -91,7 +91,7 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
         "SQLite",
         N_PTS,
         async || {
-            let m = SqliteMemory::new(
+            let m = SqliteMemory::new_with_path(
                 SQLITE_PATH,
                 "bench_memory_search_multiple_bindings".to_string(),
             )
@@ -130,7 +130,7 @@ fn bench_search_multiple_keywords(c: &mut Criterion) {
     bench_memory_search_multiple_keywords(
         "Redis",
         N_PTS,
-        async || RedisMemory::connect(&get_redis_url()).await.unwrap(),
+        async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
         c,
         &mut rng,
     );
@@ -140,7 +140,7 @@ fn bench_search_multiple_keywords(c: &mut Criterion) {
         "SQLite",
         N_PTS,
         async || {
-            let m = SqliteMemory::new(
+            let m = SqliteMemory::new_with_path(
                 SQLITE_PATH,
                 "bench_memory_search_multiple_keywords".to_string(),
             )
@@ -177,7 +177,7 @@ fn bench_insert_multiple_bindings(c: &mut Criterion) {
     bench_memory_insert_multiple_bindings(
         "Redis",
         N_PTS,
-        async || RedisMemory::connect(&get_redis_url()).await.unwrap(),
+        async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
         c,
         RedisMemory::clear,
         &mut rng,
@@ -188,7 +188,7 @@ fn bench_insert_multiple_bindings(c: &mut Criterion) {
         "SQLite",
         N_PTS,
         async || {
-            let m = SqliteMemory::new(
+            let m = SqliteMemory::new_with_path(
                 SQLITE_PATH,
                 "bench_memory_insert_multiple_bindings".to_string(),
             )
@@ -229,7 +229,7 @@ fn bench_contention(c: &mut Criterion) {
     bench_memory_contention(
         "Redis",
         N_PTS,
-        async || RedisMemory::connect(&get_redis_url()).await.unwrap(),
+        async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
         c,
         RedisMemory::clear,
         &mut rng,
@@ -240,7 +240,7 @@ fn bench_contention(c: &mut Criterion) {
         "SQLite",
         N_PTS,
         async || {
-            let m = SqliteMemory::new(SQLITE_PATH, "bench_memory_contention".to_string())
+            let m = SqliteMemory::new_with_path(SQLITE_PATH, "bench_memory_contention".to_string())
                 .await
                 .unwrap();
             m.initialize().await.unwrap();
@@ -368,7 +368,7 @@ fn bench_one_to_many(c: &mut Criterion) {
             N_PTS,
             async || {
                 DelayedMemory::new(
-                    RedisMemory::connect(&get_redis_url()).await.unwrap(),
+                    RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
                     *mean,
                     *variance,
                 )

--- a/crate/memories/benches/benches.rs
+++ b/crate/memories/benches/benches.rs
@@ -61,14 +61,14 @@ async fn connect_and_init_table(
     pg_config.url = Some(db_url.to_string());
     let test_pool = pg_config.builder(NoTls)?.build()?;
 
-    let m = PostgresMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect_with_pool(
+    let m = PostgresMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::new_with_pool(
         test_pool,
         table_name.to_string(),
     )
-    .await?;
+    .await;
 
-    m.initialize_table(db_url.to_string(), table_name, NoTls)
-        .await?;
+    m.initialize().await?;
+
     Ok(m)
 }
 // Number of points in each graph.
@@ -91,12 +91,14 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
         "SQLite",
         N_PTS,
         async || {
-            SqliteMemory::connect(
+            let m = SqliteMemory::new(
                 SQLITE_PATH,
                 "bench_memory_search_multiple_bindings".to_string(),
             )
             .await
-            .unwrap()
+            .unwrap();
+            m.initialize().await.unwrap();
+            m
         },
         c,
         &mut rng,
@@ -107,12 +109,14 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
         "Postgres",
         N_PTS,
         async || {
-            connect_and_init_table(
+            let m = connect_and_init_table(
                 get_postgresql_url(),
                 "bench_memory_search_multiple_bindings".to_string(),
             )
             .await
-            .unwrap()
+            .unwrap();
+            m.initialize().await.unwrap();
+            m
         },
         c,
         &mut rng,
@@ -136,12 +140,14 @@ fn bench_search_multiple_keywords(c: &mut Criterion) {
         "SQLite",
         N_PTS,
         async || {
-            SqliteMemory::connect(
+            let m = SqliteMemory::new(
                 SQLITE_PATH,
                 "bench_memory_search_multiple_keywords".to_string(),
             )
             .await
-            .unwrap()
+            .unwrap();
+            m.initialize().await.unwrap();
+            m
         },
         c,
         &mut rng,
@@ -182,12 +188,14 @@ fn bench_insert_multiple_bindings(c: &mut Criterion) {
         "SQLite",
         N_PTS,
         async || {
-            SqliteMemory::connect(
+            let m = SqliteMemory::new(
                 SQLITE_PATH,
                 "bench_memory_insert_multiple_bindings".to_string(),
             )
             .await
-            .unwrap()
+            .unwrap();
+            m.initialize().await.unwrap();
+            m
         },
         c,
         SqliteMemory::clear,
@@ -232,9 +240,11 @@ fn bench_contention(c: &mut Criterion) {
         "SQLite",
         N_PTS,
         async || {
-            SqliteMemory::connect(SQLITE_PATH, "bench_memory_contention".to_string())
+            let m = SqliteMemory::new(SQLITE_PATH, "bench_memory_contention".to_string())
                 .await
-                .unwrap()
+                .unwrap();
+            m.initialize().await.unwrap();
+            m
         },
         c,
         SqliteMemory::clear,

--- a/crate/memories/examples/postgresql.rs
+++ b/crate/memories/examples/postgresql.rs
@@ -40,7 +40,8 @@ async fn main() {
     // Generating a random index.
     let index = gen_index(&mut rng);
 
-    // Addd the following service to your pg_service.conf file (usually under ~/.pg_service.conf):
+    // Addd the following service to your pg_service.conf file (usually under
+    // `~/.pg_service.conf`):
     //
     // [cosmian_service]
     // host=localhost
@@ -48,20 +49,17 @@ async fn main() {
     // user=cosmian
     // password=cosmian
     let pool = create_pool(DB_URL).await.unwrap();
-    let m = PostgresMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect_with_pool(
+    let m = PostgresMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::new_with_pool(
         pool.clone(),
         TABLE_NAME.to_string(),
     )
-    .await
-    .unwrap();
+    .await;
 
     // Notice we chose to not enable TLS: it's not needed for this example as we
     // are using the encryption layer in top of the memory interface - i.e. the
     // data is already encrypted before being sent to the database and TLS would
     // add unnecessary overhead.
-    m.initialize_table(DB_URL.to_string(), TABLE_NAME.to_string(), NoTls)
-        .await
-        .unwrap();
+    m.initialize().await.unwrap();
 
     let encrypted_memory = MemoryEncryptionLayer::new(&key, m);
 

--- a/crate/memories/examples/redis.rs
+++ b/crate/memories/examples/redis.rs
@@ -28,7 +28,7 @@ async fn main() {
     let index = gen_index(&mut rng);
 
     // This example uses our Redis-based implementation of `MemoryADT`.
-    let memory = RedisMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect(DB_PATH)
+    let memory = RedisMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::new_with_url(DB_PATH)
         .await
         .unwrap();
 

--- a/crate/memories/examples/sqlite.rs
+++ b/crate/memories/examples/sqlite.rs
@@ -28,9 +28,10 @@ async fn main() {
     // Generating the random index.
     let index = gen_index(&mut rng);
 
-    let memory = SqliteMemory::<_, [u8; WORD_LENGTH]>::new(DB_PATH, TABLE_NAME.to_owned())
-        .await
-        .unwrap();
+    let memory =
+        SqliteMemory::<_, [u8; WORD_LENGTH]>::new_with_path(DB_PATH, TABLE_NAME.to_owned())
+            .await
+            .unwrap();
 
     let encrypted_memory = MemoryEncryptionLayer::new(&key, memory);
 

--- a/crate/memories/examples/sqlite.rs
+++ b/crate/memories/examples/sqlite.rs
@@ -28,7 +28,7 @@ async fn main() {
     // Generating the random index.
     let index = gen_index(&mut rng);
 
-    let memory = SqliteMemory::<_, [u8; WORD_LENGTH]>::connect(DB_PATH, TABLE_NAME.to_owned())
+    let memory = SqliteMemory::<_, [u8; WORD_LENGTH]>::new(DB_PATH, TABLE_NAME.to_owned())
         .await
         .unwrap();
 

--- a/crate/memories/src/lib.rs
+++ b/crate/memories/src/lib.rs
@@ -22,7 +22,5 @@ pub mod reexport {
     #[cfg(feature = "redis-mem")]
     pub use redis;
     #[cfg(feature = "postgres-mem")]
-    pub use tokio;
-    #[cfg(feature = "postgres-mem")]
     pub use tokio_postgres;
 }

--- a/crate/memories/src/postgresql_mem/memory.rs
+++ b/crate/memories/src/postgresql_mem/memory.rs
@@ -129,7 +129,7 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
                     .transpose()
                     .map_err(PostgresMemoryError::TryFromSliceError)
             })
-            .collect::<Result<_, Self::Error>>()
+            .collect()
     }
 
     async fn guarded_write(

--- a/crate/memories/src/postgresql_mem/memory.rs
+++ b/crate/memories/src/postgresql_mem/memory.rs
@@ -2,10 +2,6 @@ use super::PostgresMemoryError;
 use cosmian_findex::{Address, MemoryADT};
 use deadpool_postgres::Pool;
 use std::marker::PhantomData;
-use tokio_postgres::{
-    Socket,
-    tls::{MakeTlsConnect, TlsConnect},
-};
 
 #[derive(Clone, Debug)]
 pub struct PostgresMemory<Address, Word> {
@@ -17,65 +13,38 @@ pub struct PostgresMemory<Address, Word> {
 impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize>
     PostgresMemory<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>
 {
-    /// Connect to a Postgres database and create a table if it doesn't exist
-    pub async fn initialize_table<T>(
-        &self,
-        db_url: String,
-        table_name: String,
-        tls: T,
-    ) -> Result<(), PostgresMemoryError>
-    where
-        T: MakeTlsConnect<Socket> + Send,
-        T::Stream: Send + 'static,
-        T::TlsConnect: Send,
-        <T::TlsConnect as TlsConnect<Socket>>::Future: Send,
-    {
-        let (client, connection) = tokio_postgres::connect(&db_url, tls).await?;
+    /// Returns a new memory instance from the given connection pool to a
+    /// PostgreSQL database.
+    pub async fn new_with_pool(pool: Pool, table_name: String) -> Self {
+        Self {
+            pool,
+            table_name,
+            _marker: PhantomData,
+        }
+    }
 
-        // The connection object performs the actual communication with the database
-        // `Connection` only resolves when the connection is closed, either because a fatal error has
-        // occurred, or because its associated `Client` has dropped and all outstanding work has completed.
-        let conn_handle = tokio::spawn(async move {
-            if let Err(e) = connection.await {
-                eprintln!("connection error: {}", e);
-            }
-        });
-
-        let returned = client
+    /// Connects to a PostgreSQL database and creates a table if it doesn't
+    /// exist.
+    pub async fn initialize(&self) -> Result<(), PostgresMemoryError> {
+        self.pool
+            .get()
+            .await?
             .execute(
                 &format!(
-                    "
-                    CREATE TABLE IF NOT EXISTS {} (
+                    "CREATE TABLE IF NOT EXISTS {} (
                         a BYTEA PRIMARY KEY CHECK (octet_length(a) = {}),
                         w BYTEA NOT NULL CHECK (octet_length(w) = {})
                     );",
-                    table_name, ADDRESS_LENGTH, WORD_LENGTH
+                    self.table_name, ADDRESS_LENGTH, WORD_LENGTH
                 ),
                 &[],
             )
             .await?;
-        if returned != 0 {
-            return Err(PostgresMemoryError::TableCreationError(returned));
-        }
 
-        drop(client);
-        let _ = conn_handle.await; // ensures that the connection is closed
         Ok(())
     }
 
-    /// Connect to a Postgres database and create a table if it doesn't exist
-    pub async fn connect_with_pool(
-        pool: Pool,
-        table_name: String,
-    ) -> Result<Self, PostgresMemoryError> {
-        Ok(Self {
-            pool,
-            table_name,
-            _marker: PhantomData,
-        })
-    }
-
-    /// Deletes all rows from the findex memory table
+    /// Clears all bindings from this memory.
     #[cfg(feature = "test-utils")]
     pub async fn clear(&self) -> Result<(), PostgresMemoryError> {
         self.pool
@@ -83,66 +52,12 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize>
             .await?
             .execute(&format!("TRUNCATE TABLE {};", self.table_name), &[])
             .await?;
+
         Ok(())
     }
-}
 
-impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
-    for PostgresMemory<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>
-{
-    type Address = Address<ADDRESS_LENGTH>;
-    type Word = [u8; WORD_LENGTH];
-    type Error = PostgresMemoryError;
-
-    async fn batch_read(
-        &self,
-        addresses: Vec<Self::Address>,
-    ) -> Result<Vec<Option<Self::Word>>, Self::Error> {
-        let client = self.pool.get().await?;
-        // statements are cached per connection and not per pool
-        let stmt = client
-            .prepare_cached(
-                format!(
-                    "SELECT f.w
-                        FROM UNNEST($1::bytea[]) WITH ORDINALITY AS params(addr, idx)
-                        LEFT JOIN {} f ON params.addr = f.a
-                        ORDER BY params.idx;",
-                    self.table_name
-                )
-                .as_str(),
-            )
-            .await?;
-
-        client
-            // the left join is necessary to ensure that the order of the addresses is preserved
-            // as well as to return None for addresses that don't exist
-            .query(
-                &stmt,
-                &[&addresses
-                    .iter()
-                    .map(|addr| addr.as_slice())
-                    .collect::<Vec<_>>()],
-            )
-            .await?
-            .iter()
-            .map(|row| {
-                let bytes_slice: Option<&[u8]> = row.try_get("w")?; // `row.get(0)` can panic
-                bytes_slice.map_or(Ok(None), |slice| {
-                    slice
-                        .try_into()
-                        .map(Some)
-                        .map_err(|_| PostgresMemoryError::InvalidDataLength(slice.len()))
-                })
-            })
-            .collect()
-    }
-
-    async fn guarded_write(
-        &self,
-        guard: (Self::Address, Option<Self::Word>),
-        bindings: Vec<(Self::Address, Self::Word)>,
-    ) -> Result<Option<Self::Word>, Self::Error> {
-        let g_write_script = format!(
+    fn gwrite_script(&self) -> String {
+        format!(
             "
         WITH
         guard_check AS (
@@ -167,20 +82,74 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
         )
         SELECT COALESCE((SELECT w FROM guard_check)) AS original_guard_value;",
             self.table_name
-        );
+        )
+    }
+}
 
+impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
+    for PostgresMemory<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>
+{
+    type Address = Address<ADDRESS_LENGTH>;
+    type Word = [u8; WORD_LENGTH];
+    type Error = PostgresMemoryError;
+
+    async fn batch_read(
+        &self,
+        addresses: Vec<Self::Address>,
+    ) -> Result<Vec<Option<Self::Word>>, Self::Error> {
+        let client = self.pool.get().await?;
+
+        // Statements are cached per connection and not per pool.
+        let stmt = client
+            .prepare_cached(&format!(
+                // The left join is necessary to ensure that the order of the
+                // addresses is preserved as well as to return None for addresses
+                // that don't exist.
+                "SELECT f.w
+                        FROM UNNEST($1::bytea[]) WITH ORDINALITY AS params(addr, idx)
+                        LEFT JOIN {} f ON params.addr = f.a
+                        ORDER BY params.idx;",
+                self.table_name
+            ))
+            .await?;
+
+        client
+            .query(
+                &stmt,
+                &[&addresses
+                    .iter()
+                    .map(|addr| addr.as_slice())
+                    .collect::<Vec<_>>()],
+            )
+            .await?
+            .iter()
+            .map(|row| {
+                row.try_get::<_, Option<&[u8]>>("w")?
+                    .map(Self::Word::try_from)
+                    .transpose()
+                    .map_err(PostgresMemoryError::TryFromSliceError)
+            })
+            .collect::<Result<_, Self::Error>>()
+    }
+
+    async fn guarded_write(
+        &self,
+        guard: (Self::Address, Option<Self::Word>),
+        bindings: Vec<(Self::Address, Self::Word)>,
+    ) -> Result<Option<Self::Word>, Self::Error> {
         let (addresses, words): (Vec<[u8; ADDRESS_LENGTH]>, Vec<Self::Word>) =
             bindings.into_iter().map(|(a, w)| (*a, w)).unzip();
-        const MAX_RETRIES: usize = 10;
 
-        for _ in 0..MAX_RETRIES {
-            // while counterintuitive, getting a new client on each retry is a better approach
-            // than trying to reuse the same client since it allows other operations to use the
-            // connection between retries.
+        // Since a guarded write operation is lock-free, this loop is guaranteed
+        // to terminate.
+        loop {
+            // Do not lock a resource for a potentially long loop, instead
+            // request a new one at each iteration.
             let mut client = self.pool.get().await?;
-            let stmt = client.prepare_cached(g_write_script.as_str()).await?;
 
-            let result = async {
+            let stmt = client.prepare_cached(&self.gwrite_script()).await?;
+
+            let res = async {
                 let tx = client
                     .build_transaction()
                     .isolation_level(
@@ -200,21 +169,26 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
                         ],
                     )
                     .await?
-                    .map_or(
-                        Ok::<Option<[u8; WORD_LENGTH]>, PostgresMemoryError>(None),
-                        |row| {
-                            row.try_get::<_, Option<&[u8]>>(0)?
-                                .map_or(Ok(None), |r| Ok(Some(r.try_into()?)))
-                        },
-                    )?;
+                    .map(|row| {
+                        row.try_get::<_, Option<&[u8]>>(0)?
+                            .map(Self::Word::try_from)
+                            .transpose()
+                            .map_err(PostgresMemoryError::TryFromSliceError)
+                    })
+                    .transpose()?
+                    .flatten();
+
                 tx.commit().await?;
+
                 Ok(res)
             }
             .await;
-            match result {
+
+            match res {
                 Ok(value) => return Ok(value),
                 Err(err) => {
-                    // Retry on serialization failures (error code 40001), otherwise fail and return the error
+                    // Retry on serialization failures (error code 40001),
+                    // otherwise fail and return the error
                     if let PostgresMemoryError::TokioPostgresError(pg_err) = &err {
                         if pg_err.code().is_some_and(|code| code.code() == "40001") {
                             continue;
@@ -224,28 +198,29 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
                 }
             }
         }
-        Err(PostgresMemoryError::RetryExhaustedError(MAX_RETRIES))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    // To run the postgresql tests locally, add the following service to your pg_service.conf file
-    // (usually under ~/.pg_service.conf):
-    //
-    // [cosmian_service]
-    // host=localhost
-    // dbname=cosmian
-    // user=cosmian
-    // password=cosmian
-    use deadpool_postgres::Config;
-    use tokio_postgres::NoTls;
+    //! To run the postgresql tests locally, add the following service to your
+    //! pg_service.conf file (usually under `~/.pg_service.conf`):
+    //!
+    //! ```
+    //! [cosmian_service]
+    //! host=localhost
+    //! dbname=cosmian
+    //! user=cosmian
+    //! password=cosmian
+    //! ```
 
     use super::*;
     use cosmian_findex::{
         ADDRESS_LENGTH, WORD_LENGTH, gen_seed, test_guarded_write_concurrent, test_rw_same_address,
         test_single_write_and_read, test_wrong_guard,
     };
+    use deadpool_postgres::Config;
+    use tokio_postgres::NoTls;
 
     const DB_URL: &str = "postgres://cosmian:cosmian@localhost/cosmian";
 
@@ -257,7 +232,8 @@ mod tests {
         Ok(pool)
     }
 
-    // Setup function that handles pool creation, memory initialization, test execution, and cleanup
+    // Setup function that handles pool creation, memory initialization, test
+    // execution, and cleanup
     async fn setup_and_run_test<F, Fut>(
         table_name: &str,
         test_fn: F,
@@ -267,14 +243,9 @@ mod tests {
         Fut: std::future::Future<Output = ()> + Send,
     {
         let test_pool = create_testing_pool(DB_URL).await.unwrap();
-        let m = PostgresMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect_with_pool(
-            test_pool.clone(),
-            table_name.to_string(),
-        )
-        .await?;
+        let m = PostgresMemory::new_with_pool(test_pool.clone(), table_name.to_string()).await;
 
-        m.initialize_table(DB_URL.to_string(), table_name.to_string(), NoTls)
-            .await?;
+        m.initialize().await?;
 
         test_fn(m).await;
 
@@ -292,14 +263,13 @@ mod tests {
     async fn test_initialization() -> Result<(), PostgresMemoryError> {
         let table_name: &str = "test_initialization";
         let test_pool = create_testing_pool(DB_URL).await.unwrap();
-        let m = PostgresMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::connect_with_pool(
+        let m = PostgresMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::new_with_pool(
             test_pool.clone(),
             table_name.to_string(),
         )
-        .await?;
+        .await;
 
-        m.initialize_table(DB_URL.to_string(), table_name.to_string(), NoTls)
-            .await?;
+        m.initialize().await?;
 
         // check that the table actually exists
         let client = test_pool.get().await?;
@@ -328,7 +298,7 @@ mod tests {
     #[tokio::test]
     async fn test_rw_seq() -> Result<(), PostgresMemoryError> {
         setup_and_run_test("findex_test_rw_seq", |m| async move {
-            test_single_write_and_read::<WORD_LENGTH, _>(&m, gen_seed()).await;
+            test_single_write_and_read(&m, gen_seed()).await;
         })
         .await
     }
@@ -336,7 +306,7 @@ mod tests {
     #[tokio::test]
     async fn test_guard_seq() -> Result<(), PostgresMemoryError> {
         setup_and_run_test("findex_test_guard_seq", |m| async move {
-            test_wrong_guard::<WORD_LENGTH, _>(&m, gen_seed()).await;
+            test_wrong_guard(&m, gen_seed()).await;
         })
         .await
     }
@@ -344,7 +314,7 @@ mod tests {
     #[tokio::test]
     async fn test_rw_same_address_seq() -> Result<(), PostgresMemoryError> {
         setup_and_run_test("findex_test_rw_same_address_seq", |m| async move {
-            test_rw_same_address::<WORD_LENGTH, _>(&m, gen_seed()).await;
+            test_rw_same_address(&m, gen_seed()).await;
         })
         .await
     }
@@ -352,7 +322,7 @@ mod tests {
     #[tokio::test]
     async fn test_rw_ccr() -> Result<(), PostgresMemoryError> {
         setup_and_run_test("findex_test_rw_ccr", |m| async move {
-            test_guarded_write_concurrent::<WORD_LENGTH, _>(&m, gen_seed(), Some(100)).await;
+            test_guarded_write_concurrent(&m, gen_seed(), Some(100)).await;
         })
         .await
     }

--- a/crate/memories/src/sqlite_mem.rs
+++ b/crate/memories/src/sqlite_mem.rs
@@ -82,7 +82,7 @@ impl<Address, Word> SqliteMemory<Address, Word> {
         // - synchronous = NORMAL: Reduces disk I/O by only calling fsync() at critical
         //   moments rather than after every transaction (FULL mode); this does not
         //   compromise data integrity.
-        let table_name = format!(
+        let initialization_script = format!(
             "PRAGMA synchronous = NORMAL;
              PRAGMA journal_mode = WAL;
              CREATE TABLE IF NOT EXISTS {} (
@@ -93,7 +93,7 @@ impl<Address, Word> SqliteMemory<Address, Word> {
         );
 
         self.pool
-            .conn(move |conn| conn.execute_batch(&table_name))
+            .conn(move |conn| conn.execute_batch(&initialization_script))
             .await?;
         Ok(())
     }

--- a/crate/memories/src/sqlite_mem.rs
+++ b/crate/memories/src/sqlite_mem.rs
@@ -50,7 +50,7 @@ impl<Address, Word> Debug for SqliteMemory<Address, Word> {
 impl<Address, Word> SqliteMemory<Address, Word> {
     /// Returns a new memory instance using a pool of connections to the SQLite
     /// database at the given path.
-    pub async fn new(
+    pub async fn new_with_path(
         path: impl AsRef<std::path::Path>,
         table_name: String,
     ) -> Result<Self, SqliteMemoryError> {
@@ -213,7 +213,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rw_seq() {
-        let m = SqliteMemory::<_, [u8; WORD_LENGTH]>::new(DB_PATH, TABLE_NAME.to_owned())
+        let m = SqliteMemory::<_, [u8; WORD_LENGTH]>::new_with_path(DB_PATH, TABLE_NAME.to_owned())
             .await
             .unwrap();
         m.initialize().await.unwrap();
@@ -222,7 +222,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_guard_seq() {
-        let m = SqliteMemory::<_, [u8; WORD_LENGTH]>::new(DB_PATH, TABLE_NAME.to_owned())
+        let m = SqliteMemory::<_, [u8; WORD_LENGTH]>::new_with_path(DB_PATH, TABLE_NAME.to_owned())
             .await
             .unwrap();
         m.initialize().await.unwrap();
@@ -231,7 +231,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_collision_seq() {
-        let m = SqliteMemory::<_, [u8; WORD_LENGTH]>::new(DB_PATH, TABLE_NAME.to_owned())
+        let m = SqliteMemory::<_, [u8; WORD_LENGTH]>::new_with_path(DB_PATH, TABLE_NAME.to_owned())
             .await
             .unwrap();
         m.initialize().await.unwrap();
@@ -240,7 +240,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_rw_ccr() {
-        let m = SqliteMemory::<_, [u8; WORD_LENGTH]>::new(DB_PATH, TABLE_NAME.to_owned())
+        let m = SqliteMemory::<_, [u8; WORD_LENGTH]>::new_with_path(DB_PATH, TABLE_NAME.to_owned())
             .await
             .unwrap();
         m.initialize().await.unwrap();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.87.0"
 components = ["rustfmt"]


### PR DESCRIPTION
- rationalize dependencies (remove redundant features, move dependencies in dev where possible, group dependencies by features...);
- upgrade toolchain (now using v1.87);
- upgrade all dependencies;
- refactor PgSQL memory and others (minors)

# Breaking change

Both SQL memories now need to be *initialized* before use.