### PR TITLE
[Style] Cargo fmt update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: push
 
 jobs:
   cargo-lint:
-    uses: Cosmian/reusable_workflows/.github/workflows/cargo-nursery.yml@develop
+    uses: Cosmian/reusable_workflows/.github/workflows/cargo-nursery.yml@feat/format_nightly_only
     with:
       toolchain: 1.87.0
       workspace: true
@@ -14,5 +14,5 @@ jobs:
   cleanup:
     needs:
       - cargo-lint
-    uses: Cosmian/reusable_workflows/.github/workflows/cleanup_cache.yml@develop
+    uses: Cosmian/reusable_workflows/.github/workflows/cleanup_cache.yml@feat/format_nightly_only
     secrets: inherit

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,6 +1,9 @@
 # Specifies which edition is used by the parser.
 # Default value: "2015"
-edition = "2021"
+edition = "2024"
+
+# The default formatting produced by Rustfmt is governed by the rules in the Rust Style Guide.
+style_edition = "2024"
 
 # How imports should be grouped into use statements. Imports will be merged or split to the configured level of granularity.
 # Default value: Preserve
@@ -37,7 +40,3 @@ use_field_init_shorthand = true
 # Break comments to fit on the line
 # Default value: false
 wrap_comments = true
-
-# Which version of the formatting rules to use. Version::One is backwards-compatible with Rustfmt 1.0. Other versions are only backwards compatible within a major version number.
-# Default value: "One"
-version = "Two"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crate/findex", "crate/memories"]
 resolver = "2"
 
 [workspace.package]
-version = "8.0.0"
+version = "8.0.1"
 authors = [
     "Bruno Grieder <bruno.grieder@cosmian.com>",
     "Célia Corsin <celia.corsin@cosmian.com>",

--- a/crate/findex/README.md
+++ b/crate/findex/README.md
@@ -8,7 +8,7 @@ Add `cosmian_findex` as dependency to your project :
 
 ```toml
 [dependencies]
-cosmian_findex = "8.0.0"
+cosmian_findex = "8.0.1"
 ```
 
 An usage example is available in the [examples folder](./examples).

--- a/crate/findex/benches/benches.rs
+++ b/crate/findex/benches/benches.rs
@@ -57,8 +57,7 @@ async fn connect_and_init_table(
     db_url: String,
     table_name: String,
 ) -> Result<PostgresMemory<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>, PostgresMemoryError> {
-    use cosmian_sse_memories::reexport::deadpool_postgres::Config;
-    use cosmian_sse_memories::reexport::tokio_postgres::NoTls;
+    use cosmian_sse_memories::reexport::{deadpool_postgres::Config, tokio_postgres::NoTls};
 
     let mut pg_config = Config::new();
     pg_config.url = Some(db_url.to_string());
@@ -318,12 +317,13 @@ fn bench_contention(c: &mut Criterion) {
 }
 
 mod delayed_memory {
+    use std::time::Duration;
+
     use cosmian_sse_memories::{
         Address, MemoryADT, PostgresMemory, PostgresMemoryError, RedisMemory, RedisMemoryError,
     };
     use rand::Rng;
     use rand_distr::StandardNormal;
-    use std::time::Duration;
 
     #[derive(Clone, Debug)]
     pub struct DelayedMemory<Memory> {
@@ -333,8 +333,8 @@ mod delayed_memory {
     }
 
     impl<Memory> DelayedMemory<Memory> {
-        /// Wrap the given memory into a new delayed memory with an average network
-        /// delay of s milliseconds.
+        /// Wrap the given memory into a new delayed memory with an average
+        /// network delay of s milliseconds.
         pub fn new(m: Memory, mean: usize, variance: usize) -> Self {
             Self { m, mean, variance }
         }
@@ -349,10 +349,8 @@ mod delayed_memory {
 
     impl<Memory: Send + Sync + MemoryADT> MemoryADT for DelayedMemory<Memory> {
         type Address = Memory::Address;
-
-        type Word = Memory::Word;
-
         type Error = Memory::Error;
+        type Word = Memory::Word;
 
         async fn batch_read(
             &self,

--- a/crate/findex/examples/databases.rs
+++ b/crate/findex/examples/databases.rs
@@ -1,6 +1,9 @@
-//! This example show-cases the use of Findex to securely store a hash-map with different back ends.
+//! This example show-cases the use of Findex to securely store a hash-map with
+//! different back ends.
 #[path = "shared_utils.rs"]
 mod shared_utils;
+
+use std::collections::HashMap;
 
 use cosmian_crypto_core::{CsRng, Secret, reexport::rand_core::SeedableRng};
 use cosmian_findex::{Findex, IndexADT, MemoryEncryptionLayer};
@@ -12,7 +15,6 @@ use cosmian_sse_memories::{
     },
 };
 use shared_utils::{WORD_LENGTH, decoder, encoder, gen_index};
-use std::collections::HashMap;
 
 const REDIS_URL: &str = "redis://localhost:6379";
 const SQLITE_DB_PATH: &str = "./target/debug/sqlite-test.db";
@@ -54,8 +56,8 @@ async fn main() {
     .await
     .unwrap();
 
-    // Or else, the Postgres-based implementation of `MemoryADT`. Refer to README.md for details on how to setup
-    // the database to use this example.
+    // Or else, the Postgres-based implementation of `MemoryADT`. Refer to README.md
+    // for details on how to setup the database to use this example.
     let pool = create_pool(PGSQL_URL).await.unwrap();
     let _postgres_memory =
         PostgresMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::new_with_pool(

--- a/crate/findex/examples/in_memory.rs
+++ b/crate/findex/examples/in_memory.rs
@@ -1,11 +1,12 @@
 //! This example show-cases the use of Findex to securely store a hash-map.
+use std::collections::{HashMap, HashSet};
+
 use cosmian_crypto_core::{
     CsRng, Secret,
     reexport::rand_core::{CryptoRngCore, SeedableRng},
 };
 use cosmian_findex::{Findex, IndexADT, MemoryEncryptionLayer, Op};
 use cosmian_sse_memories::InMemory;
-use std::collections::{HashMap, HashSet};
 
 /// This function generates a random set of (key, values) couples. Since Findex
 /// API is those of an Index which only returns the *set* of values associated

--- a/crate/findex/examples/shared_utils.rs
+++ b/crate/findex/examples/shared_utils.rs
@@ -1,6 +1,7 @@
+use std::collections::{HashMap, HashSet};
+
 use cosmian_crypto_core::reexport::rand_core::CryptoRngCore;
 use cosmian_findex::Op;
-use std::collections::{HashMap, HashSet};
 
 /// This function generates a random set of (key, values) couples. Since Findex
 /// API is those of an Index which only returns the *set* of values associated

--- a/crate/findex/src/adt.rs
+++ b/crate/findex/src/adt.rs
@@ -1,8 +1,10 @@
-//! We define here the main Abstract Data Types (ADTs) used in this crate, namely:
+//! We define here the main Abstract Data Types (ADTs) used in this crate,
+//! namely:
 //! - the index ADT;
 //! - the vector ADT;
 //!
-//! Each of them strive for simplicity and consistency with the classical CS notions.
+//! Each of them strive for simplicity and consistency with the classical CS
+//! notions.
 
 use std::{collections::HashSet, future::Future, hash::Hash};
 

--- a/crate/findex/src/benches.rs
+++ b/crate/findex/src/benches.rs
@@ -1,14 +1,16 @@
 //! This module provides a comprehensive benchmarking suite for testing the
 //! performance of Findex memory implementations. These benchmarks are designed
-//! to be generic and work with any memory back end that implements the MemoryADT
-//! trait.
+//! to be generic and work with any memory back end that implements the
+//! MemoryADT trait.
 
-use crate::{Findex, IndexADT, MemoryEncryptionLayer, WORD_LENGTH, dummy_decode, dummy_encode};
+use std::{collections::HashSet, fmt::Debug, sync::Arc};
+
 use agnostic_lite::{JoinHandle, RuntimeLite};
 use cosmian_crypto_core::{Secret, reexport::rand_core::CryptoRngCore};
 use cosmian_sse_memories::{ADDRESS_LENGTH, Address, MemoryADT};
 use criterion::{BenchmarkId, Criterion};
-use std::{collections::HashSet, fmt::Debug, sync::Arc};
+
+use crate::{Findex, IndexADT, MemoryEncryptionLayer, WORD_LENGTH, dummy_decode, dummy_encode};
 
 const MAX_VAL: usize = 1_000;
 

--- a/crate/findex/src/encoding.rs
+++ b/crate/findex/src/encoding.rs
@@ -3,8 +3,9 @@
 //! deletion, but there is no theoretical restriction on the kind of operation
 //! that can be used.
 
-use crate::Op;
 use std::collections::HashSet;
+
+use crate::Op;
 
 /// The encoder is used to serialize an operation, along with the set of values
 /// it operates on, into a sequence of memory words.
@@ -20,8 +21,8 @@ pub mod dummy_encoding {
 
     use super::*;
 
-    /// Blocks are the smallest unit size in block mode, 16 bytes is optimized to
-    /// store UUIDs.
+    /// Blocks are the smallest unit size in block mode, 16 bytes is optimized
+    /// to store UUIDs.
     const BLOCK_LENGTH: usize = 16;
 
     /// The chunk length is the size of the available space in a word.
@@ -267,16 +268,15 @@ pub mod generic_encoding {
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod tests {
+    use std::{collections::HashSet, fmt::Debug, hash::Hash};
+
     use cosmian_crypto_core::{
         CsRng,
         reexport::rand_core::{RngCore, SeedableRng},
     };
 
-    use crate::Op;
-
-    use std::{collections::HashSet, fmt::Debug, hash::Hash};
-
     use super::{Decoder, Encoder};
+    use crate::Op;
 
     /// Uses fuzzing to attempt asserting that: encode ∘ decode = identity.
     ///

--- a/crate/findex/src/encryption_layer.rs
+++ b/crate/findex/src/encryption_layer.rs
@@ -1,10 +1,11 @@
+use std::{fmt::Debug, ops::Deref, sync::Arc};
+
 use aes::{
     Aes256,
     cipher::{BlockEncrypt, KeyInit, generic_array::GenericArray},
 };
 use cosmian_crypto_core::{Secret, SymmetricKey};
 use cosmian_sse_memories::{ADDRESS_LENGTH, Address, MemoryADT};
-use std::{fmt::Debug, ops::Deref, sync::Arc};
 use xts_mode::Xts128;
 
 /// Using 32-byte cryptographic keys allows achieving post-quantum resistance
@@ -90,10 +91,8 @@ impl<
 > MemoryADT for MemoryEncryptionLayer<WORD_LENGTH, Memory>
 {
     type Address = Address<ADDRESS_LENGTH>;
-
-    type Word = [u8; WORD_LENGTH];
-
     type Error = Memory::Error;
+    type Word = [u8; WORD_LENGTH];
 
     async fn batch_read(
         &self,
@@ -132,7 +131,6 @@ impl<
 
 #[cfg(test)]
 mod tests {
-    use crate::MemoryEncryptionLayer;
     use cosmian_crypto_core::{
         CsRng, Sampling, Secret,
         reexport::rand_core::{CryptoRngCore, SeedableRng},
@@ -143,6 +141,8 @@ mod tests {
             gen_seed, test_guarded_write_concurrent, test_single_write_and_read, test_wrong_guard,
         },
     };
+
+    use crate::MemoryEncryptionLayer;
 
     const WORD_LENGTH: usize = 128;
 

--- a/crate/findex/src/findex.rs
+++ b/crate/findex/src/findex.rs
@@ -86,9 +86,11 @@ impl<
         a
     }
 
-    /// Pushes the given bindings to the vectors associated to the bound keyword.
+    /// Pushes the given bindings to the vectors associated to the bound
+    /// keyword.
     ///
-    /// All vector push operations are performed in parallel (via async calls), not batched.
+    /// All vector push operations are performed in parallel (via async calls),
+    /// not batched.
     async fn push<Keyword: Send + Sync + Hash + Eq>(
         &self,
         op: Op,
@@ -138,11 +140,13 @@ impl<
 
 #[cfg(test)]
 mod tests {
-    use crate::{Findex, IndexADT, MemoryEncryptionLayer, dummy_decode, dummy_encode};
+    use std::{collections::HashSet, sync::Arc};
+
     use cosmian_crypto_core::{CsRng, Secret, define_byte_type, reexport::rand_core::SeedableRng};
     use cosmian_sse_memories::{ADDRESS_LENGTH, Address, InMemory};
     use smol_macros::Executor;
-    use std::{collections::HashSet, sync::Arc};
+
+    use crate::{Findex, IndexADT, MemoryEncryptionLayer, dummy_decode, dummy_encode};
 
     // Define a byte type, and use `Value` as an alias for 8-bytes values of
     // that type.
@@ -152,6 +156,7 @@ mod tests {
 
     impl<const LENGTH: usize> TryFrom<usize> for Bytes<LENGTH> {
         type Error = String;
+
         fn try_from(value: usize) -> Result<Self, Self::Error> {
             Self::try_from(value.to_be_bytes().as_slice()).map_err(|e| e.to_string())
         }
@@ -206,8 +211,8 @@ mod tests {
         assert_eq!(HashSet::new(), dog_res);
     }
 
-    // The next test uses the `smol` executor to run the async code, forcasting that findex
-    // can be used in a different async runtime.
+    // The next test uses the `smol` executor to run the async code, forcasting that
+    // findex can be used in a different async runtime.
     smol_macros::test! {
         async fn test_insert_search_delete_search_smol(executor: &Executor<'_>) {
             let mut rng = CsRng::from_entropy();

--- a/crate/findex/src/lib.rs
+++ b/crate/findex/src/lib.rs
@@ -14,24 +14,21 @@ mod ovec;
 
 #[cfg(feature = "test-utils")]
 mod benches;
+pub use adt::IndexADT;
 #[cfg(feature = "test-utils")]
 pub use benches::*;
-
-pub use adt::IndexADT;
 pub use encoding::{
     Decoder, Encoder,
     generic_encoding::{generic_decode, generic_encode},
 };
-pub use encryption_layer::{KEY_LENGTH, MemoryEncryptionLayer};
-pub use error::Error;
-pub use findex::Findex;
-pub use findex::Op;
-
 #[cfg(any(test, feature = "test-utils"))]
 pub use encoding::{
     dummy_encoding::{WORD_LENGTH, dummy_decode, dummy_encode},
     tests::test_encoding,
 };
+pub use encryption_layer::{KEY_LENGTH, MemoryEncryptionLayer};
+pub use error::Error;
+pub use findex::{Findex, Op};
 
 #[cfg(feature = "test-utils")]
 pub mod reexport {

--- a/crate/findex/src/ovec.rs
+++ b/crate/findex/src/ovec.rs
@@ -1,11 +1,13 @@
-//! This module implements a simple vector, defined as a data-structure that preserves the
-//! following invariant:
+//! This module implements a simple vector, defined as a data-structure that
+//! preserves the following invariant:
 //!
-//! `I_v`: the value of the counter stored at the vector address is equal to the number of values
-//! stored in this vector; these values are of homogeneous type and stored in contiguous memory words.
+//! `I_v`: the value of the counter stored at the vector address is equal to the
+//! number of values stored in this vector; these values are of homogeneous type
+//! and stored in contiguous memory words.
 //!
-//! This implementation is based on the assumption that an infinite array starting at the vector's
-//! address has been allocated, and thus stores values after the header:
+//! This implementation is based on the assumption that an infinite array
+//! starting at the vector's address has been allocated, and thus stores values
+//! after the header:
 //!
 //! ```txt
 //! +------------+-----+-----+-----+
@@ -14,10 +16,11 @@
 //!      a         a+1   ...  a+n+1
 //! ```
 
+use std::{fmt::Debug, hash::Hash, ops::Add};
+
 use cosmian_sse_memories::MemoryADT;
 
 use crate::{adt::VectorADT, error::Error};
-use std::{fmt::Debug, hash::Hash, ops::Add};
 
 /// Headers contain a counter of the number of values stored in the vector.
 // TODO: header could store metadata (e.g. sparsity budget)
@@ -93,8 +96,8 @@ impl<
     Memory: Clone + MemoryADT<Address = Address, Word = [u8; WORD_LENGTH]>,
 > IVec<WORD_LENGTH, Memory>
 {
-    /// (Lazily) instantiates a new vector at this address in this memory: no value is written
-    /// before the first push.
+    /// (Lazily) instantiates a new vector at this address in this memory: no
+    /// value is written before the first push.
     pub const fn new(a: Address, m: Memory) -> Self {
         Self { a, m }
     }
@@ -108,17 +111,16 @@ impl<
 where
     Memory::Error: Send,
 {
+    type Error = Error<Memory::Address>;
     type Value = Memory::Word;
 
-    type Error = Error<Memory::Address>;
-
     async fn push(&mut self, values: Vec<Self::Value>) -> Result<(), Self::Error> {
-        // Findex modifications are only lock-free, hence it does not guarantee a given client will
-        // ever terminate.
+        // Findex modifications are only lock-free, hence it does not guarantee a given
+        // client will ever terminate.
         //
-        // TODO: this loop will arguably terminate if the index is not highly contended, but we
-        // need a stronger guarantee. Maybe a return with an error after reaching a certain
-        // number of retries.
+        // TODO: this loop will arguably terminate if the index is not highly contended,
+        // but we need a stronger guarantee. Maybe a return with an error after
+        // reaching a certain number of retries.
         let mut old = Option::<Header>::None;
         loop {
             // Generates a new header with incremented counter.

--- a/crate/memories/src/address.rs
+++ b/crate/memories/src/address.rs
@@ -1,5 +1,6 @@
-use cosmian_crypto_core::define_byte_type;
 use std::ops::Add;
+
+use cosmian_crypto_core::define_byte_type;
 
 // An address is a little-endian number encoded on LENGTH bytes.
 define_byte_type!(Address);
@@ -9,7 +10,8 @@ impl<const LENGTH: usize> Copy for Address<LENGTH> {}
 impl<const LENGTH: usize> Add<u64> for Address<LENGTH> {
     type Output = Self;
 
-    /// Highly inefficient implementation of an add modulo 2^8^LENGTH in little endian.
+    /// Highly inefficient implementation of an add modulo 2^8^LENGTH in little
+    /// endian.
     fn add(mut self, mut adder: u64) -> Self::Output {
         let mut carry = 0;
         let mut pos = 0;

--- a/crate/memories/src/databases/postgresql_mem/memory.rs
+++ b/crate/memories/src/databases/postgresql_mem/memory.rs
@@ -1,7 +1,9 @@
+use std::marker::PhantomData;
+
+use deadpool_postgres::Pool;
+
 use super::PostgresMemoryError;
 use crate::{Address, MemoryADT};
-use deadpool_postgres::Pool;
-use std::marker::PhantomData;
 
 #[derive(Clone, Debug)]
 pub struct PostgresMemory<Address, Word> {
@@ -90,8 +92,8 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
     for PostgresMemory<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>
 {
     type Address = Address<ADDRESS_LENGTH>;
-    type Word = [u8; WORD_LENGTH];
     type Error = PostgresMemoryError;
+    type Word = [u8; WORD_LENGTH];
 
     async fn batch_read(
         &self,
@@ -203,6 +205,10 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
 
 #[cfg(test)]
 mod tests {
+    use deadpool_postgres::Config;
+    use tokio_postgres::NoTls;
+
+    use super::*;
     use crate::{
         ADDRESS_LENGTH,
         test_utils::{
@@ -210,10 +216,6 @@ mod tests {
             test_single_write_and_read, test_wrong_guard,
         },
     };
-
-    use super::*;
-    use deadpool_postgres::Config;
-    use tokio_postgres::NoTls;
 
     const DB_URL: &str = "postgres://cosmian:cosmian@localhost/cosmian";
 

--- a/crate/memories/src/databases/redis_mem.rs
+++ b/crate/memories/src/databases/redis_mem.rs
@@ -1,5 +1,6 @@
-use redis::aio::ConnectionManager;
 use std::{fmt, marker::PhantomData};
+
+use redis::aio::ConnectionManager;
 
 use crate::{MemoryADT, address::Address};
 
@@ -99,8 +100,8 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
     for RedisMemory<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>
 {
     type Address = Address<ADDRESS_LENGTH>;
-    type Word = [u8; WORD_LENGTH];
     type Error = RedisMemoryError;
+    type Word = [u8; WORD_LENGTH];
 
     async fn batch_read(
         &self,
@@ -143,12 +144,11 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
 #[cfg(test)]
 mod tests {
 
+    use super::*;
     use crate::test_utils::{
         gen_seed, test_guarded_write_concurrent, test_rw_same_address, test_single_write_and_read,
         test_wrong_guard,
     };
-
-    use super::*;
 
     fn get_redis_url() -> String {
         std::env::var("REDIS_HOST").map_or_else(

--- a/crate/memories/src/databases/sqlite_mem.rs
+++ b/crate/memories/src/databases/sqlite_mem.rs
@@ -1,14 +1,16 @@
-use crate::{Address, MemoryADT};
-use async_sqlite::{
-    Pool, PoolBuilder,
-    rusqlite::{OptionalExtension, params_from_iter},
-};
 use std::{
     collections::HashMap,
     fmt::{self, Debug},
     marker::PhantomData,
     ops::Deref,
 };
+
+use async_sqlite::{
+    Pool, PoolBuilder,
+    rusqlite::{OptionalExtension, params_from_iter},
+};
+
+use crate::{Address, MemoryADT};
 
 #[derive(Debug)]
 pub enum SqliteMemoryError {
@@ -75,14 +77,14 @@ impl<Address, Word> SqliteMemory<Address, Word> {
         }
     }
 
-    /// Creates the correct table in the associated database if it does not exist.
+    /// Creates the correct table in the associated database if it does not
+    /// exist.
     pub async fn initialize(&self) -> Result<(), SqliteMemoryError> {
         // The following settings are used to improve performance:
-        // - journal_mode = WAL : WAL journaling is faster than the default
-        //   DELETE mode.
-        // - synchronous = NORMAL: Reduces disk I/O by only calling fsync() at
-        //   critical moments rather than after every transaction (FULL mode);
-        //   this does not compromise data integrity.
+        // - journal_mode = WAL : WAL journaling is faster than the default DELETE mode.
+        // - synchronous = NORMAL: Reduces disk I/O by only calling fsync() at critical
+        //   moments rather than after every transaction (FULL mode); this does not
+        //   compromise data integrity.
         let initialization_script = format!(
             "PRAGMA synchronous = NORMAL;
              PRAGMA journal_mode = WAL;
@@ -203,12 +205,11 @@ impl<const ADDRESS_LENGTH: usize, const WORD_LENGTH: usize> MemoryADT
 #[cfg(test)]
 mod tests {
 
+    use super::*;
     use crate::test_utils::{
         gen_seed, test_guarded_write_concurrent, test_rw_same_address, test_single_write_and_read,
         test_wrong_guard,
     };
-
-    use super::*;
 
     const DB_PATH: &str = "../../target/debug/sqlite-test.sqlite.db";
     const TABLE_NAME: &str = "findex_memory";

--- a/crate/memories/src/in_memory.rs
+++ b/crate/memories/src/in_memory.rs
@@ -49,10 +49,8 @@ impl<Address: Send + Hash + Eq + Debug, Value: Send + Clone + Eq + Debug> Memory
     for InMemory<Address, Value>
 {
     type Address = Address;
-
-    type Word = Value;
-
     type Error = MemoryError;
+    type Word = Value;
 
     async fn batch_read(&self, addresses: Vec<Address>) -> Result<Vec<Option<Value>>, Self::Error> {
         let store = self.inner.lock().expect("poisoned lock");
@@ -79,9 +77,8 @@ impl<Address: Send + Hash + Eq + Debug, Value: Send + Clone + Eq + Debug> Memory
 impl<Address: Hash + Eq + Debug + Clone, Value: Clone + Eq + Debug> IntoIterator
     for InMemory<Address, Value>
 {
-    type Item = (Address, Value);
-
     type IntoIter = <HashMap<Address, Value> as IntoIterator>::IntoIter;
+    type Item = (Address, Value);
 
     fn into_iter(self) -> Self::IntoIter {
         self.inner
@@ -95,12 +92,13 @@ impl<Address: Hash + Eq + Debug + Clone, Value: Clone + Eq + Debug> IntoIterator
 #[cfg(test)]
 mod tests {
 
+    use smol_macros::{Executor, test};
+
     use super::InMemory;
     use crate::test_utils::{
         gen_seed, test_guarded_write_concurrent, test_rw_same_address, test_single_write_and_read,
         test_wrong_guard,
     };
-    use smol_macros::{Executor, test};
 
     const TEST_ADDRESS_LENGTH: usize = 16;
     const TEST_WORD_LENGTH: usize = 16;

--- a/crate/memories/src/lib.rs
+++ b/crate/memories/src/lib.rs
@@ -3,16 +3,13 @@ mod databases;
 mod in_memory;
 
 pub use address::Address;
-pub use in_memory::InMemory;
-
-#[cfg(feature = "redis-mem")]
-pub use databases::redis_mem::{RedisMemory, RedisMemoryError};
-
-#[cfg(feature = "sqlite-mem")]
-pub use databases::sqlite_mem::{SqliteMemory, SqliteMemoryError};
-
 #[cfg(feature = "postgres-mem")]
 pub use databases::postgresql_mem::{PostgresMemory, PostgresMemoryError};
+#[cfg(feature = "redis-mem")]
+pub use databases::redis_mem::{RedisMemory, RedisMemoryError};
+#[cfg(feature = "sqlite-mem")]
+pub use databases::sqlite_mem::{SqliteMemory, SqliteMemoryError};
+pub use in_memory::InMemory;
 
 pub mod reexport {
     #[cfg(feature = "sqlite-mem")]

--- a/crate/memories/src/test_utils/memory_tests.rs
+++ b/crate/memories/src/test_utils/memory_tests.rs
@@ -8,13 +8,15 @@
 //!
 //! Both addresses and words are 16-byte long.
 
-use crate::{ADDRESS_LENGTH, MemoryADT};
+use std::fmt::Debug;
+
 use agnostic_lite::AsyncSpawner;
 use cosmian_crypto_core::{
     CsRng,
     reexport::rand_core::{RngCore, SeedableRng},
 };
-use std::fmt::Debug;
+
+use crate::{ADDRESS_LENGTH, MemoryADT};
 
 pub const SEED_LENGTH: usize = 32;
 
@@ -147,8 +149,10 @@ pub async fn test_wrong_guard<const WORD_LENGTH: usize, Memory>(
 
 /// Tests operations on repeated addresses in memory implementations.
 ///
-/// This test verifies the behavior when the same address is used multiple times:
-/// 1. Writes a value to an address and then confirms it can be read back multiple times consistently
+/// This test verifies the behavior when the same address is used multiple
+/// times:
+/// 1. Writes a value to an address and then confirms it can be read back
+///    multiple times consistently
 /// 2. Performs multiple writes to the same address with a correct guard
 /// 3. Verifies that one of the written values is properly stored
 pub async fn test_rw_same_address<const WORD_LENGTH: usize, Memory>(
@@ -186,7 +190,8 @@ pub async fn test_rw_same_address<const WORD_LENGTH: usize, Memory>(
         seed
     );
 
-    // try to write multiple values to the same address with a guard that should pass
+    // try to write multiple values to the same address with a guard that should
+    // pass
     let values = (0..REPETITION)
         .map(|_| Memory::Word::from(gen_bytes(&mut rng)))
         .collect::<Vec<_>>();
@@ -308,7 +313,7 @@ pub async fn test_guarded_write_concurrent<const WORD_LENGTH: usize, Memory, Spa
         word_to_array(final_count.clone().into()).unwrap(),
         (n * M) as u128,
         "test_guarded_write_concurrent failed. Expected the counter to be at {:?}, found \
-             {:?}.\nDebug seed : {:?}.",
+         {:?}.\nDebug seed : {:?}.",
         (n * M) as u128,
         word_to_array(final_count.into()).unwrap(),
         seed


### PR DESCRIPTION
Very minor PR

I noticed that cargo fmt file has not been changed since 3 years and is out of date with other repositories

In this PR I only changed (manually) the file **.rustfmt.toml** + updated the cargo toml version + the ci on this pr : https://github.com/Cosmian/reusable_workflows/pull/54

By the way, the `version` option is deprecated. I use `style_edition` instead.

All the other diffs are stricly auto reformatted

## ⚠️  Notice

Oddly enough some rules were written in that file yet not applied to the repo.

Example : 
pub use findex::Findex;
pub use findex::Op;

should have been merged in 1 line.

After reading the CI, exactly here : 

<img width="1523" height="614" alt="image" src="https://github.com/user-attachments/assets/87cc7635-a8fd-4a9b-9d5f-190090e27bc4" />

Do notice that the **rust fmt** check uses the default available channel to check formatting **but almost of the rules we use are from the nightly channel**

In order to avoid falsly green CIs, I will proceed to make an update to use the nightly channel ONLY for formatting via 
```bash
cargo +nightly fmt --all -- --check --color always
 ```

IMO as long as the CI continues to mistake the formatting channel, we will always have this problem
<img width="1088" height="620" alt="image" src="https://github.com/user-attachments/assets/c37d1213-f6ad-4828-ba0a-ef1acc34eacd" />

Workflow link : https://github.com/Cosmian/findex/actions/runs/16972645804/job/48113380578?pr=155