### PR TITLE
fix: remove paste and agnostic deps

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -17,7 +17,7 @@ jobs:
   bench:
     uses: Cosmian/reusable_workflows/.github/workflows/cargo-bench.yml@develop
     with:
-      toolchain: 1.87.0
+      toolchain: 1.90.0
       features: test-utils
       force: true
       redis-host: "redis"

--- a/.github/workflows/hack.yml
+++ b/.github/workflows/hack.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.87.0
+          toolchain: 1.90.0
           override: true
       - name: Install cargo-hack
         run: cargo install --locked cargo-hack || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
   cargo-lint:
     uses: ./.github/workflows/ci.yml
     with:
-      toolchain: 1.87.0
+      toolchain: 1.90.0
   cleanup:
     needs:
       - cargo-lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,9 @@ readme = "README.md"
 
 
 [workspace.dependencies]
-agnostic-lite = { version = ">=0.5.6" }
 cosmian_crypto_core = { version = "10.2", default-features = false, features = [
     "macro",
     "sha3",
 ] }
 criterion = { version = "0.6" }
-smol-macros = { version = "0.1" }
 tokio = { version = "1.46" }

--- a/crate/findex/Cargo.toml
+++ b/crate/findex/Cargo.toml
@@ -15,7 +15,7 @@ name = "cosmian_findex"
 path = "src/lib.rs"
 
 [features]
-test-utils = ["agnostic-lite", "criterion"]
+test-utils = ["tokio", "criterion"]
 
 [dependencies]
 aes = "0.8"
@@ -24,15 +24,10 @@ cosmian_sse_memories = { path = "../memories", version = "8.0" }
 xts-mode = "0.5"
 
 # Optional dependencies for testing and benchmarking.
-agnostic-lite = { workspace = true, optional = true, features = [
-    "tokio",
-    "smol",
-    "wasm",
-] }
 criterion = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true, features = ["rt-multi-thread"] }
 
 [dev-dependencies]
-agnostic-lite = { workspace = true, features = ["tokio"] }
 cosmian_sse_memories = { path = "../memories", version = "8.0", features = [
     "redis-mem",
     "sqlite-mem",
@@ -41,8 +36,7 @@ cosmian_sse_memories = { path = "../memories", version = "8.0", features = [
 ] }
 rand = "0.9"
 rand_distr = "0.5"
-smol-macros = { workspace = true }
-tokio = { version = "1.44", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [[example]]
 name = "in_memory"

--- a/crate/findex/benches/benches.rs
+++ b/crate/findex/benches/benches.rs
@@ -9,7 +9,7 @@ use cosmian_crypto_core::{
 use cosmian_findex::{
     WORD_LENGTH, bench_memory_contention, bench_memory_insert_multiple_bindings,
     bench_memory_one_to_many, bench_memory_search_multiple_bindings,
-    bench_memory_search_multiple_keywords, reexport::tokio::TokioRuntime,
+    bench_memory_search_multiple_keywords,
 };
 use cosmian_sse_memories::InMemory;
 use criterion::{Criterion, criterion_group, criterion_main};
@@ -82,18 +82,20 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
     let rt = Builder::new_multi_thread().enable_all().build().unwrap();
     let _guard = rt.enter();
 
-    bench_memory_search_multiple_bindings::<_, TokioRuntime>(
+    bench_memory_search_multiple_bindings(
         "in-memory",
         N_PTS,
+        &rt,
         async || InMemory::default(),
         c,
         &mut rng,
     );
 
     if redis_enabled {
-        bench_memory_search_multiple_bindings::<_, TokioRuntime>(
+        bench_memory_search_multiple_bindings(
             "Redis",
             N_PTS,
+            &rt,
             async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
             c,
             &mut rng,
@@ -101,9 +103,10 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
     }
 
     if sqlite_enabled {
-        bench_memory_search_multiple_bindings::<_, TokioRuntime>(
+        bench_memory_search_multiple_bindings(
             "SQLite",
             N_PTS,
+            &rt,
             async || {
                 let m = SqliteMemory::new_with_path(SQLITE_PATH, "bench_memory_smd".to_string())
                     .await
@@ -117,9 +120,10 @@ fn bench_search_multiple_bindings(c: &mut Criterion) {
     }
 
     if postgres_enabled {
-        bench_memory_search_multiple_bindings::<_, TokioRuntime>(
+        bench_memory_search_multiple_bindings(
             "Postgres",
             N_PTS,
+            &rt,
             async || {
                 let m =
                     connect_and_init_table(get_postgresql_url(), "bench_memory_smd".to_string())
@@ -139,18 +143,20 @@ fn bench_search_multiple_keywords(c: &mut Criterion) {
     let rt = Builder::new_multi_thread().enable_all().build().unwrap();
     let _guard = rt.enter();
 
-    bench_memory_search_multiple_keywords::<_, TokioRuntime>(
+    bench_memory_search_multiple_keywords(
         "in-memory",
         N_PTS,
+        &rt,
         async || InMemory::default(),
         c,
         &mut rng,
     );
 
     if redis_enabled {
-        bench_memory_search_multiple_keywords::<_, TokioRuntime>(
+        bench_memory_search_multiple_keywords(
             "Redis",
             N_PTS,
+            &rt,
             async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
             c,
             &mut rng,
@@ -158,9 +164,10 @@ fn bench_search_multiple_keywords(c: &mut Criterion) {
     }
 
     if sqlite_enabled {
-        bench_memory_search_multiple_keywords::<_, TokioRuntime>(
+        bench_memory_search_multiple_keywords(
             "SQLite",
             N_PTS,
+            &rt,
             async || {
                 let m = SqliteMemory::new_with_path(SQLITE_PATH, "bench_memory_smk".to_string())
                     .await
@@ -174,9 +181,10 @@ fn bench_search_multiple_keywords(c: &mut Criterion) {
     }
 
     if postgres_enabled {
-        bench_memory_search_multiple_keywords::<_, TokioRuntime>(
+        bench_memory_search_multiple_keywords(
             "Postgres",
             N_PTS,
+            &rt,
             async || {
                 connect_and_init_table(get_postgresql_url(), "bench_memory_smk".to_string())
                     .await
@@ -193,9 +201,10 @@ fn bench_insert_multiple_bindings(c: &mut Criterion) {
     let rt = Builder::new_multi_thread().enable_all().build().unwrap();
     let _guard = rt.enter();
 
-    bench_memory_insert_multiple_bindings::<_, _, TokioRuntime>(
+    bench_memory_insert_multiple_bindings(
         "in-memory",
         N_PTS,
+        &rt,
         async || InMemory::default(),
         c,
         async |m: &InMemory<_, _>| -> Result<(), String> {
@@ -206,9 +215,10 @@ fn bench_insert_multiple_bindings(c: &mut Criterion) {
     );
 
     if redis_enabled {
-        bench_memory_insert_multiple_bindings::<_, _, TokioRuntime>(
+        bench_memory_insert_multiple_bindings(
             "Redis",
             N_PTS,
+            &rt,
             async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
             c,
             RedisMemory::clear,
@@ -217,9 +227,10 @@ fn bench_insert_multiple_bindings(c: &mut Criterion) {
     }
 
     if sqlite_enabled {
-        bench_memory_insert_multiple_bindings::<_, _, TokioRuntime>(
+        bench_memory_insert_multiple_bindings(
             "SQLite",
             N_PTS,
+            &rt,
             async || {
                 let m = SqliteMemory::new_with_path(SQLITE_PATH, "bench_memory_imd".to_string())
                     .await
@@ -234,9 +245,10 @@ fn bench_insert_multiple_bindings(c: &mut Criterion) {
     }
 
     if postgres_enabled {
-        bench_memory_insert_multiple_bindings::<_, _, TokioRuntime>(
+        bench_memory_insert_multiple_bindings(
             "Postgres",
             N_PTS,
+            &rt,
             async || {
                 connect_and_init_table(get_postgresql_url(), "bench_memory_imd".to_string())
                     .await
@@ -257,9 +269,10 @@ fn bench_contention(c: &mut Criterion) {
     let rt = Builder::new_multi_thread().enable_all().build().unwrap();
     let _guard = rt.enter();
 
-    bench_memory_contention::<_, _, TokioRuntime>(
+    bench_memory_contention(
         "in-memory",
         N_PTS,
+        &rt,
         async || InMemory::default(),
         c,
         async |m: &InMemory<_, _>| -> Result<(), String> {
@@ -270,9 +283,10 @@ fn bench_contention(c: &mut Criterion) {
     );
 
     if redis_enabled {
-        bench_memory_contention::<_, _, TokioRuntime>(
+        bench_memory_contention(
             "Redis",
             N_PTS,
+            &rt,
             async || RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
             c,
             RedisMemory::clear,
@@ -281,9 +295,10 @@ fn bench_contention(c: &mut Criterion) {
     }
 
     if sqlite_enabled {
-        bench_memory_contention::<_, _, TokioRuntime>(
+        bench_memory_contention(
             "SQLite",
             N_PTS,
+            &rt,
             async || {
                 let m =
                     SqliteMemory::new_with_path(SQLITE_PATH, "bench_memory_contention".to_string())
@@ -299,9 +314,10 @@ fn bench_contention(c: &mut Criterion) {
     }
 
     if postgres_enabled {
-        bench_memory_contention::<_, _, TokioRuntime>(
+        bench_memory_contention(
             "Postgres",
             N_PTS,
+            &rt,
             async || {
                 connect_and_init_table(get_postgresql_url(), "bench_memory_contention".to_string())
                     .await
@@ -405,9 +421,10 @@ fn bench_one_to_many(c: &mut Criterion) {
 
     if redis_enabled {
         for (mean, variance) in &delay_params {
-            bench_memory_one_to_many::<_, _, TokioRuntime>(
+            bench_memory_one_to_many(
                 "Redis",
                 N_PTS,
+                &rt,
                 async || {
                     DelayedMemory::new(
                         RedisMemory::new_with_url(&get_redis_url()).await.unwrap(),
@@ -424,9 +441,10 @@ fn bench_one_to_many(c: &mut Criterion) {
 
     if postgres_enabled {
         for (mean, variance) in &delay_params {
-            bench_memory_one_to_many::<_, _, TokioRuntime>(
+            bench_memory_one_to_many(
                 "Postgres",
                 N_PTS,
+                &rt,
                 async || {
                     let m = connect_and_init_table(
                         get_postgresql_url(),

--- a/crate/findex/src/benches.rs
+++ b/crate/findex/src/benches.rs
@@ -5,10 +5,10 @@
 
 use std::{collections::HashSet, fmt::Debug, sync::Arc};
 
-use agnostic_lite::{JoinHandle, RuntimeLite};
 use cosmian_crypto_core::{Secret, reexport::rand_core::CryptoRngCore};
 use cosmian_sse_memories::{ADDRESS_LENGTH, Address, MemoryADT};
 use criterion::{BenchmarkId, Criterion};
+use tokio::runtime::Runtime;
 
 use crate::{Findex, IndexADT, MemoryEncryptionLayer, WORD_LENGTH, dummy_decode, dummy_encode};
 
@@ -54,16 +54,16 @@ fn build_benchmarking_keywords_index(
 /// of values indexed under this keyword.
 pub fn bench_memory_search_multiple_bindings<
     Memory: Clone + Send + Sync + MemoryADT<Address = Address<ADDRESS_LENGTH>, Word = [u8; WORD_LENGTH]>,
-    BenchesRuntime: 'static + RuntimeLite,
 >(
     memory_name: &str,
     n: usize,
+    rt: &Runtime,
     m: impl AsyncFn() -> Memory,
     c: &mut Criterion,
     rng: &mut impl CryptoRngCore,
 ) {
     let findex = Findex::new(
-        MemoryEncryptionLayer::new(&Secret::random(rng), BenchesRuntime::block_on(m())),
+        MemoryEncryptionLayer::new(&Secret::random(rng), rt.block_on(m())),
         dummy_encode::<WORD_LENGTH, _>,
         dummy_decode,
     );
@@ -73,12 +73,12 @@ pub fn bench_memory_search_multiple_bindings<
     index
         .clone()
         .into_iter()
-        .for_each(|(kw, vs)| BenchesRuntime::block_on(findex.insert(kw, vs)).unwrap());
+        .for_each(|(kw, vs)| rt.block_on(findex.insert(kw, vs)).unwrap());
 
     let mut group = c.benchmark_group(format!("multiple-binding search ({})", memory_name));
     for (kw, vals) in index.iter() {
         group.bench_with_input(BenchmarkId::from_parameter(vals.len()), &(), |b, ()| {
-            b.iter(|| BenchesRuntime::block_on(findex.search(kw)).expect("search failed"));
+            b.iter(|| rt.block_on(findex.search(kw)).expect("search failed"));
         });
     }
 }
@@ -91,16 +91,16 @@ pub fn bench_memory_search_multiple_keywords<
         + Send
         + Sync
         + MemoryADT<Address = Address<ADDRESS_LENGTH>, Word = [u8; WORD_LENGTH]>,
-    BenchesRuntime: 'static + RuntimeLite,
 >(
     memory_name: &str,
     n: usize,
+    rt: &Runtime,
     m: impl AsyncFn() -> Memory,
     c: &mut Criterion,
     rng: &mut impl CryptoRngCore,
 ) {
     let findex = Arc::new(Findex::new(
-        MemoryEncryptionLayer::new(&Secret::random(rng), BenchesRuntime::block_on(m())),
+        MemoryEncryptionLayer::new(&Secret::random(rng), rt.block_on(m())),
         dummy_encode::<WORD_LENGTH, _>,
         dummy_decode,
     ));
@@ -110,7 +110,7 @@ pub fn bench_memory_search_multiple_keywords<
     index
         .clone()
         .into_iter()
-        .for_each(|(kw, vs)| BenchesRuntime::block_on(findex.insert(kw, vs)).unwrap());
+        .for_each(|(kw, vs)| rt.block_on(findex.insert(kw, vs)).unwrap());
 
     let mut group = c.benchmark_group(format!("multiple-keyword search ({memory_name})"));
     for i in make_scale(1, MAX_VAL, n) {
@@ -129,13 +129,11 @@ pub fn bench_memory_search_multiple_keywords<
                     )
                 },
                 |(kws, findex)| {
-                    BenchesRuntime::block_on(async {
+                    rt.block_on(async {
                         let mut handles = Vec::with_capacity(n);
                         for kw in kws {
                             let findex = findex.clone();
-                            handles.push(BenchesRuntime::spawn(
-                                async move { findex.search(&kw).await },
-                            ))
+                            handles.push(tokio::spawn(async move { findex.search(&kw).await }))
                         }
                         for res in handles {
                             res.await.expect("Search task failed").unwrap();
@@ -157,16 +155,16 @@ pub fn bench_memory_insert_multiple_bindings<
         + Send
         + Sync
         + MemoryADT<Address = Address<ADDRESS_LENGTH>, Word = [u8; WORD_LENGTH]>,
-    BenchesRuntime: 'static + RuntimeLite,
 >(
     memory_name: &str,
     n: usize,
+    rt: &Runtime,
     m: impl AsyncFn() -> Memory,
     c: &mut Criterion,
     clear: impl AsyncFn(&Memory) -> Result<(), E>,
     rng: &mut impl CryptoRngCore,
 ) {
-    let mut m = BenchesRuntime::block_on(m());
+    let mut m = rt.block_on(m());
 
     let findex = Arc::new(Findex::new(
         MemoryEncryptionLayer::new(&Secret::random(rng), m.clone()),
@@ -179,17 +177,17 @@ pub fn bench_memory_insert_multiple_bindings<
     index
         .clone()
         .into_iter()
-        .for_each(|(kw, vs)| BenchesRuntime::block_on(findex.insert(kw, vs)).unwrap());
+        .for_each(|(kw, vs)| rt.block_on(findex.insert(kw, vs)).unwrap());
 
     let mut group = c.benchmark_group(format!("multiple-binding insert ({memory_name})"));
     for (kw, vs) in index.into_iter() {
         group.bench_function(BenchmarkId::from_parameter(vs.len()), |b| {
             b.iter_batched(
                 || {
-                    BenchesRuntime::block_on(clear(&mut m)).unwrap();
+                    rt.block_on(clear(&mut m)).unwrap();
                     (kw, vs.clone())
                 },
-                |(kw, vs)| BenchesRuntime::block_on(findex.insert(kw, vs)).expect("search failed"),
+                |(kw, vs)| rt.block_on(findex.insert(kw, vs)).expect("search failed"),
                 criterion::BatchSize::SmallInput,
             );
         });
@@ -206,10 +204,10 @@ pub fn bench_memory_contention<
         + Send
         + Sync
         + MemoryADT<Address = Address<ADDRESS_LENGTH>, Word = [u8; WORD_LENGTH]>,
-    BenchesRuntime: 'static + RuntimeLite,
 >(
     memory_name: &str,
     n: usize,
+    rt: &Runtime,
     m: impl AsyncFn() -> Memory,
     c: &mut Criterion,
     clear: impl AsyncFn(&Memory) -> Result<(), E>,
@@ -217,7 +215,7 @@ pub fn bench_memory_contention<
 ) {
     const N_CLIENTS: usize = 10;
 
-    let m = BenchesRuntime::block_on(m());
+    let m = rt.block_on(m());
 
     let findex = Arc::new(Findex::new(
         MemoryEncryptionLayer::new(&Secret::random(rng), m.clone()),
@@ -241,16 +239,14 @@ pub fn bench_memory_contention<
             group.bench_function(BenchmarkId::from_parameter(n_clients), |b| {
                 b.iter_batched(
                     || {
-                        BenchesRuntime::block_on(clear(&m)).unwrap();
+                        rt.block_on(clear(&m)).unwrap();
                         (0..n_clients).map(|_| findex.clone()).zip(bindings.clone())
                     },
                     |iterator| {
-                        BenchesRuntime::block_on(async {
+                        rt.block_on(async {
                             let handles = iterator
                                 .map(|(findex, (kw, vs))| {
-                                    BenchesRuntime::spawn(
-                                        async move { findex.insert(kw, vs).await },
-                                    )
+                                    tokio::spawn(async move { findex.insert(kw, vs).await })
                                 })
                                 .collect::<Vec<_>>();
                             for h in handles {
@@ -281,19 +277,16 @@ pub fn bench_memory_contention<
             group.bench_function(BenchmarkId::from_parameter(n_clients), |b| {
                 b.iter_batched(
                     || {
-                        BenchesRuntime::block_on(clear(&m)).unwrap();
+                        rt.block_on(clear(&m)).unwrap();
                         (
                             Vec::with_capacity(n_clients),
                             (0..n_clients).map(|_| findex.clone()).zip(bindings.clone()),
                         )
                     },
                     |(mut handles, iterator)| {
-                        BenchesRuntime::block_on(async {
+                        rt.block_on(async {
                             for (findex, (kw, vs)) in iterator {
-                                let h =
-                                    BenchesRuntime::spawn(
-                                        async move { findex.insert(kw, vs).await },
-                                    );
+                                let h = tokio::spawn(async move { findex.insert(kw, vs).await });
                                 handles.push(h);
                             }
                             for h in handles {
@@ -317,10 +310,10 @@ pub fn bench_memory_one_to_many<
         + Send
         + Sync
         + MemoryADT<Address = Address<ADDRESS_LENGTH>, Word = [u8; WORD_LENGTH]>,
-    BenchesRuntime: 'static + RuntimeLite,
 >(
     memory_name: &str,
     n: usize,
+    rt: &Runtime,
     m: impl AsyncFn() -> Memory,
     c: &mut Criterion,
     clear: impl AsyncFn(&Memory) -> Result<(), E>,
@@ -328,7 +321,7 @@ pub fn bench_memory_one_to_many<
 ) {
     const MAX_VAL: usize = 100;
 
-    let m = BenchesRuntime::block_on(m());
+    let m = rt.block_on(m());
 
     let findex = Arc::new(Findex::new(
         MemoryEncryptionLayer::new(&Secret::random(rng), m.clone()),
@@ -348,16 +341,16 @@ pub fn bench_memory_one_to_many<
             group.bench_function(BenchmarkId::from_parameter(n_clients), |b| {
                 b.iter_batched(
                     || {
-                        BenchesRuntime::block_on(clear(&m)).unwrap();
+                        rt.block_on(clear(&m)).unwrap();
                         (
                             Vec::with_capacity(n_clients),
                             (0..n_clients).map(|_| (findex.clone(), vs.clone())),
                         )
                     },
                     |(mut handles, iterator)| {
-                        BenchesRuntime::block_on(async {
+                        rt.block_on(async {
                             for (findex, vs) in iterator {
-                                handles.push(BenchesRuntime::spawn(async move {
+                                handles.push(tokio::spawn(async move {
                                     loop {
                                         findex.insert(kw, vs.clone()).await.unwrap();
                                     }
@@ -365,7 +358,7 @@ pub fn bench_memory_one_to_many<
                             }
 
                             let findex = findex.clone();
-                            BenchesRuntime::spawn(async move {
+                            tokio::spawn(async move {
                                 let kw = kw;
                                 findex.search(&kw).await.unwrap();
                             })
@@ -396,15 +389,15 @@ pub fn bench_memory_one_to_many<
             group.bench_function(BenchmarkId::from_parameter(n_clients), |b| {
                 b.iter_batched(
                     || {
-                        BenchesRuntime::block_on(clear(&m)).unwrap();
+                        rt.block_on(clear(&m)).unwrap();
                     },
                     |_| {
-                        BenchesRuntime::block_on(async {
+                        rt.block_on(async {
                             let mut handles = Vec::new();
                             for _ in 0..n_clients {
                                 let findex = findex.clone();
                                 let vs = vs.clone();
-                                handles.push(BenchesRuntime::spawn(async move {
+                                handles.push(tokio::spawn(async move {
                                     loop {
                                         findex.insert(kw, vs.clone()).await.unwrap();
                                     }
@@ -413,7 +406,7 @@ pub fn bench_memory_one_to_many<
 
                             let findex = findex.clone();
                             let vs = vs.clone();
-                            BenchesRuntime::spawn(async move {
+                            tokio::spawn(async move {
                                 let kw = kw;
                                 findex.insert(&kw, vs).await.unwrap();
                             })

--- a/crate/findex/src/encryption_layer.rs
+++ b/crate/findex/src/encryption_layer.rs
@@ -182,11 +182,6 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_read_write() {
         let mem = create_memory(&mut CsRng::from_entropy());
-        test_guarded_write_concurrent::<16, _, agnostic_lite::tokio::TokioSpawner>(
-            &mem,
-            gen_seed(),
-            None,
-        )
-        .await;
+        test_guarded_write_concurrent::<16, _>(&mem, gen_seed(), None).await;
     }
 }

--- a/crate/findex/src/findex.rs
+++ b/crate/findex/src/findex.rs
@@ -144,7 +144,6 @@ mod tests {
 
     use cosmian_crypto_core::{CsRng, Secret, define_byte_type, reexport::rand_core::SeedableRng};
     use cosmian_sse_memories::{ADDRESS_LENGTH, Address, InMemory};
-    use smol_macros::Executor;
 
     use crate::{Findex, IndexADT, MemoryEncryptionLayer, dummy_decode, dummy_encode};
 
@@ -211,62 +210,44 @@ mod tests {
         assert_eq!(HashSet::new(), dog_res);
     }
 
-    // The next test uses the `smol` executor to run the async code, forcasting that
-    // findex can be used in a different async runtime.
-    smol_macros::test! {
-        async fn test_insert_search_delete_search_smol(executor: &Executor<'_>) {
-            let mut rng = CsRng::from_entropy();
-            let seed = Secret::random(&mut rng);
-            let memory = MemoryEncryptionLayer::new(
-                &seed,
-                InMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::default(),
-            );
+    #[tokio::test]
+    async fn test_insert_search_delete_search_concurrent_tokio() {
+        let mut rng = CsRng::from_entropy();
+        let seed = Secret::random(&mut rng);
+        let memory = MemoryEncryptionLayer::new(
+            &seed,
+            InMemory::<Address<ADDRESS_LENGTH>, [u8; WORD_LENGTH]>::default(),
+        );
 
-            let findex = Findex::new(memory, dummy_encode::<WORD_LENGTH, Value>, dummy_decode);
+        let findex = Findex::new(memory, dummy_encode::<WORD_LENGTH, Value>, dummy_decode);
 
-            // Test concurrent inserts to the same keyword
-            let values1 = Arc::new([
-                Value::try_from(1).unwrap(),
-                Value::try_from(2).unwrap(),
-            ]);
-            let values2 = Arc::new([
-                Value::try_from(3).unwrap(),
-                Value::try_from(4).unwrap(),
-            ]);
-            let values3 = Arc::new([
-                Value::try_from(5).unwrap(),
-                Value::try_from(6).unwrap(),
-            ]);
+        // Test concurrent inserts to the same keyword
+        let values1 = Arc::new([Value::try_from(1).unwrap(), Value::try_from(2).unwrap()]);
+        let values2 = Arc::new([Value::try_from(3).unwrap(), Value::try_from(4).unwrap()]);
+        let values3 = Arc::new([Value::try_from(5).unwrap(), Value::try_from(6).unwrap()]);
 
-            // Spawn concurrent insert operations
-            let findex1 = findex.clone();
-            let findex2 = findex.clone();
-            let findex3 = findex.clone();
+        let expected: HashSet<Value> = values1
+            .iter()
+            .chain(values2.iter())
+            .chain(values3.iter())
+            .cloned()
+            .collect();
 
-            let expected: HashSet<Value> = values1.iter()
-                .chain(values2.iter())
-                .chain(values3.iter())
-                .cloned()
-                .collect();
+        let findex1 = findex.clone();
+        let findex2 = findex.clone();
+        let findex3 = findex.clone();
 
-            let task1 =  executor.spawn(async move {
-                findex1.insert("spider".to_string(), (*values1).clone()).await
-            });
-            let task2 =  executor.spawn(async move {
-                findex2.insert("spider".to_string(), (*values2).clone()).await
-            });
-            let task3 =  executor.spawn(async move {
-                findex3.insert("spider".to_string(), (*values3).clone()).await
-            });
+        let (r1, r2, r3) = tokio::join!(
+            findex1.insert("spider".to_string(), (*values1).clone()),
+            findex2.insert("spider".to_string(), (*values2).clone()),
+            findex3.insert("spider".to_string(), (*values3).clone()),
+        );
 
-            // Wait for all inserts to complete
-            task1.await.unwrap();
-            task2.await.unwrap();
-            task3.await.unwrap();
+        r1.unwrap();
+        r2.unwrap();
+        r3.unwrap();
 
-             // Search and verify all values are present
-            let result = findex.search(&"spider".to_string()).await.unwrap();
-            assert_eq!(expected, result);
-        }
+        let result = findex.search(&"spider".to_string()).await.unwrap();
+        assert_eq!(expected, result);
     }
 }

--- a/crate/findex/src/lib.rs
+++ b/crate/findex/src/lib.rs
@@ -29,9 +29,3 @@ pub use encoding::{
 pub use encryption_layer::{KEY_LENGTH, MemoryEncryptionLayer};
 pub use error::Error;
 pub use findex::{Findex, Op};
-
-#[cfg(feature = "test-utils")]
-pub mod reexport {
-    // Re-exporting the most commonly used runtime interfaces for convenience.
-    pub use agnostic_lite::{smol, tokio, wasm};
-}

--- a/crate/memories/Cargo.toml
+++ b/crate/memories/Cargo.toml
@@ -21,7 +21,6 @@ postgres-mem = ["deadpool-postgres", "tokio", "tokio-postgres"]
 test-utils = ["tokio"]
 
 [dependencies]
-agnostic-lite = { workspace = true }
 async-sqlite = { version = "0.5", optional = true }
 cosmian_crypto_core.workspace = true
 deadpool-postgres = { version = "0.14", optional = true }
@@ -35,7 +34,5 @@ tokio-postgres = { version = "0.7", optional = true, features = [
 ] }
 
 [dev-dependencies]
-agnostic-lite = { workspace = true, features = ["tokio", "smol"] }
 cosmian_crypto_core.workspace = true
-smol-macros = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crate/memories/src/databases/postgresql_mem/memory.rs
+++ b/crate/memories/src/databases/postgresql_mem/memory.rs
@@ -317,12 +317,7 @@ mod tests {
     #[tokio::test]
     async fn test_rw_ccr() -> Result<(), PostgresMemoryError> {
         setup_and_run_test("findex_test_rw_ccr", |m| async move {
-            test_guarded_write_concurrent::<129, _, agnostic_lite::tokio::TokioSpawner>(
-                &m,
-                gen_seed(),
-                Some(100),
-            )
-            .await;
+            test_guarded_write_concurrent::<129, _>(&m, gen_seed(), Some(100)).await;
         })
         .await
     }

--- a/crate/memories/src/databases/redis_mem.rs
+++ b/crate/memories/src/databases/redis_mem.rs
@@ -178,11 +178,6 @@ mod tests {
     #[tokio::test]
     async fn test_rw_ccr() {
         let m = RedisMemory::new_with_url(&get_redis_url()).await.unwrap();
-        test_guarded_write_concurrent::<129, _, agnostic_lite::tokio::TokioSpawner>(
-            &m,
-            gen_seed(),
-            None,
-        )
-        .await
+        test_guarded_write_concurrent::<129, _>(&m, gen_seed(), None).await
     }
 }

--- a/crate/memories/src/databases/sqlite_mem.rs
+++ b/crate/memories/src/databases/sqlite_mem.rs
@@ -246,11 +246,6 @@ mod tests {
         let m = SqliteMemory::new_with_path(DB_PATH, TABLE_NAME.to_owned())
             .await
             .unwrap();
-        test_guarded_write_concurrent::<129, _, agnostic_lite::tokio::TokioSpawner>(
-            &m,
-            gen_seed(),
-            Some(100),
-        )
-        .await
+        test_guarded_write_concurrent::<129, _>(&m, gen_seed(), Some(100)).await
     }
 }

--- a/crate/memories/src/in_memory.rs
+++ b/crate/memories/src/in_memory.rs
@@ -92,8 +92,6 @@ impl<Address: Hash + Eq + Debug + Clone, Value: Clone + Eq + Debug> IntoIterator
 #[cfg(test)]
 mod tests {
 
-    use smol_macros::{Executor, test};
-
     use super::InMemory;
     use crate::test_utils::{
         gen_seed, test_guarded_write_concurrent, test_rw_same_address, test_single_write_and_read,
@@ -126,26 +124,6 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_read_write_tokio() {
         let memory = InMemory::<[u8; TEST_ADDRESS_LENGTH], [u8; TEST_WORD_LENGTH]>::default();
-        test_guarded_write_concurrent::<TEST_WORD_LENGTH, _, agnostic_lite::tokio::TokioSpawner>(
-            &memory,
-            gen_seed(),
-            None,
-        )
-        .await;
-    }
-
-    test! {
-        async fn test_concurrent_read_write_smol(executor: &Executor<'_>) {
-            executor.spawn(async {
-                let memory = InMemory::<[u8; TEST_ADDRESS_LENGTH], [u8; TEST_WORD_LENGTH]>::default();
-                test_guarded_write_concurrent::<TEST_WORD_LENGTH, _, agnostic_lite::smol::SmolSpawner>(
-                    &memory,
-                    gen_seed(),
-                    None,
-                )
-                .await;
-            })
-            .await;
-        }
+        test_guarded_write_concurrent::<TEST_WORD_LENGTH, _>(&memory, gen_seed(), None).await;
     }
 }

--- a/crate/memories/src/test_utils/memory_tests.rs
+++ b/crate/memories/src/test_utils/memory_tests.rs
@@ -10,11 +10,11 @@
 
 use std::fmt::Debug;
 
-use agnostic_lite::AsyncSpawner;
 use cosmian_crypto_core::{
     CsRng,
     reexport::rand_core::{RngCore, SeedableRng},
 };
+use tokio::task::JoinHandle;
 
 use crate::{ADDRESS_LENGTH, MemoryADT};
 
@@ -236,7 +236,7 @@ pub async fn test_rw_same_address<const WORD_LENGTH: usize, Memory>(
 /// * `memory` - The Memory ADT implementation to test.
 /// * `seed` - The seed used to initialize the random number generator.
 /// * `n_threads` - The number of threads to spawn. If None, defaults to 100.
-pub async fn test_guarded_write_concurrent<const WORD_LENGTH: usize, Memory, Spawner>(
+pub async fn test_guarded_write_concurrent<const WORD_LENGTH: usize, Memory>(
     memory: &Memory,
     seed: [u8; SEED_LENGTH],
     n_threads: Option<usize>,
@@ -246,7 +246,6 @@ pub async fn test_guarded_write_concurrent<const WORD_LENGTH: usize, Memory, Spa
     Memory::Word:
         Send + Debug + PartialEq + From<[u8; WORD_LENGTH]> + Into<[u8; WORD_LENGTH]> + Clone,
     Memory::Error: Send + std::error::Error,
-    Spawner: AsyncSpawner,
 {
     // A worker increment N times the counter m[a].
     async fn worker<const WORD_LENGTH: usize, Memory>(
@@ -294,15 +293,15 @@ pub async fn test_guarded_write_concurrent<const WORD_LENGTH: usize, Memory, Spa
     let mut rng = CsRng::from_seed(seed);
     let a = gen_bytes(&mut rng);
 
-    let handles = (0..n)
+    let handles: Vec<JoinHandle<Result<(), Memory::Error>>> = (0..n)
         .map(|_| {
             let m = memory.clone();
-            Spawner::spawn(worker(m, a))
+            tokio::spawn(worker::<WORD_LENGTH, Memory>(m, a))
         })
-        .collect::<Vec<_>>();
+        .collect();
 
     for handle in handles {
-        handle.await.unwrap().unwrap();
+        handle.await.expect("task join failed").unwrap();
     }
 
     let final_count = memory.batch_read(vec![a.into()]).await.unwrap()[0]

--- a/deny.toml
+++ b/deny.toml
@@ -70,7 +70,6 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-  { id = "RUSTSEC-2024-0436", reason = "A transitive dependency (`paste`) is not maintained anymore and should be replaced by its follow up `pastery` on the `agnostic_lite` project." }, #  this is temporary, an issue was opened on the culprit crate : https://github.com/al8n/agnostic/issues/26
   # { id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
   # "a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
   # { crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
@@ -94,7 +93,6 @@ allow = [
   "Apache-2.0 WITH LLVM-exception",
   "Zlib",
   "BSD-3-Clause",
-  "Unicode-DFS-2016",
   "BUSL-1.1",
   "CC0-1.0",
   "Unicode-3.0",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.90.0"
 components = ["rustfmt"]


### PR DESCRIPTION
Remove `agnostic-lite` dependency to avoid pulling `paste` crate that brings the RUSTSEC-2024-0436.

RUSTSEC-2024-0436 is next pulled in `findex-server` and `cli` repositories.